### PR TITLE
Config Refactoring

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -8,5 +8,32 @@
         "encoding": "utf8"
     },
 
+    "intervals": {
+    	"announce": "30m",
+    	"min_announce": "15m",
+    	"database_reload": "45s",
+    	"database_serialization": "68s",
+    	"purge_inactive": "83s",
+
+    	"verify_used_slots": 3600,
+
+    	"flush_sleep": "3000ms",
+
+    	"dead_lock_wait": "1000ms"
+    },
+
+    "max_deadlock_retries": 20,
+
+    "buffer_sizes": {
+    	"torrent_flush_buffer": 10000,
+    	"user_flush_buffer": 10000,
+    	"transfer_history_flush_buffer": 10000,
+    	"transfer_ips_flush_buffer": 1000,
+    	"snatch_flush_buffer": 100
+    },
+
+    "log_flushes": true,
+    "slots_enabled": true,
+
     "addr": ":34000"
 }

--- a/database/reload.go
+++ b/database/reload.go
@@ -47,7 +47,7 @@ func (db *Database) startReloading() {
 
 			count++
 			db.waitGroup.Done()
-			time.Sleep(config.DatabaseReloadInterval)
+			time.Sleep(config.Config.Intervals.DatabaseReload.Duration)
 		}
 	}()
 }
@@ -175,7 +175,7 @@ func (db *Database) loadConfig() {
 		if err != nil || row == nil {
 			break
 		} else {
-			config.GlobalFreeleech = row.Bool(0)
+			config.Config.GlobalFreeleech = row.Bool(0)
 		}
 	}
 	db.mainConn.mutex.Unlock()

--- a/database/serialization.go
+++ b/database/serialization.go
@@ -28,7 +28,7 @@ import (
 func (db *Database) startSerializing() {
 	go func() {
 		for !db.terminate {
-			time.Sleep(config.DatabaseSerializationInterval)
+			time.Sleep(config.Config.Intervals.DatabaseSerialization.Duration)
 			db.serialize()
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"chihaya/config"
 	"chihaya/server"
 	"flag"
 	"log"
@@ -45,6 +46,8 @@ func main() {
 		}
 		pprof.StartCPUProfile(f)
 	}
+
+	config.ReadConfig("config.json")
 
 	go func() {
 		c := make(chan os.Signal, 1)

--- a/server/announce.go
+++ b/server/announce.go
@@ -162,7 +162,7 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 
 	// Update peer info/stats
 	if newPeer {
-		if user.Slots != -1 && config.SlotsEnabled && !seeding {
+		if user.Slots != -1 && config.Config.SlotsEnabled && !seeding {
 			if user.UsedSlots >= user.Slots {
 				failure("You don't have enough slots free. Stop downloading something and try again.", buf)
 				return
@@ -194,7 +194,7 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 	}
 
 	var deltaDownload int64
-	if !config.GlobalFreeleech {
+	if !config.Config.GlobalFreeleech {
 		deltaDownload = int64(float64(rawDeltaDownload) * user.DownMultiplier * torrent.DownMultiplier)
 	}
 	deltaUpload := int64(float64(rawDeltaUpload) * user.UpMultiplier * torrent.UpMultiplier)
@@ -279,7 +279,7 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 	// Although slots used are still calculated for users with no restriction,
 	// we don't care as much about consistency for them. If they suddenly get a restriction,
 	// their slot count will be cleaned up on their next announce
-	if user.SlotsLastChecked+config.VerifyUsedSlotsInterval < now && user.Slots != -1 && config.SlotsEnabled {
+	if user.SlotsLastChecked+config.Config.Intervals.VerifyUsedSlots < now && user.Slots != -1 && config.Config.SlotsEnabled {
 		db.VerifyUsedSlots(user)
 		atomic.StoreInt64(&user.SlotsLastChecked, now)
 	}
@@ -294,9 +294,9 @@ func announce(params *queryParams, user *cdb.User, ip string, db *cdb.Database, 
 	util.Bencode("incomplete", buf)
 	util.Bencode(leechCount, buf)
 	util.Bencode("interval", buf)
-	util.Bencode(config.AnnounceInterval, buf)
+	util.Bencode(config.Config.Intervals.Announce.Duration, buf)
 	util.Bencode("min interval", buf)
-	util.Bencode(config.MinAnnounceInterval, buf)
+	util.Bencode(config.Config.Intervals.MinAnnounce.Duration, buf)
 
 	if numWant > 0 && active {
 		util.Bencode("peers", buf)

--- a/server/server.go
+++ b/server/server.go
@@ -295,7 +295,7 @@ func Start() {
 
 	handler.db.Init()
 
-	listener, err = net.Listen("tcp", config.Get("addr"))
+	listener, err = net.Listen("tcp", config.Config.BindAddress)
 
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Moved constants into config file
- Loaded config directly into json struct

Note: the config accessing isn't a whole hell of a lot better
`config.Config.*` as opposed to `config.Get(*)`, but it's a bit safer.

Also, intervals have been changed. They're now at config.Config.Intervals.*.
All this can be changed.

Also, it may be worth it to refactor later, moving config into a package shared with the rest of the project so it's only `config.*`
