### PR TITLE
Mock Tracker Storage

### DIFF
--- a/storage/tracker/mock/conn.go
+++ b/storage/tracker/mock/conn.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	"github.com/pushrax/chihaya/storage"
+	"github.com/pushrax/chihaya/storage/tracker"
 )
 
 type Conn struct {
@@ -19,7 +20,8 @@ func (c *Conn) FindUser(passkey string) (*storage.User, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-	return user, true, nil
+	u := *user
+	return &u, true, nil
 }
 
 func (c *Conn) FindTorrent(infohash string) (*storage.Torrent, bool, error) {
@@ -29,10 +31,13 @@ func (c *Conn) FindTorrent(infohash string) (*storage.Torrent, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-	return torrent, true, nil
+	t := *torrent
+	return &t, true, nil
 }
 
 func (c *Conn) ClientWhitelisted(peerID string) (bool, error) {
+	c.whitelistM.RLock()
+	defer c.whitelistM.RUnlock()
 	_, ok := c.whitelist[peerID]
 	if !ok {
 		return false, nil
@@ -41,69 +46,193 @@ func (c *Conn) ClientWhitelisted(peerID string) (bool, error) {
 }
 
 func (c *Conn) RecordSnatch(u *storage.User, t *storage.Torrent) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Snatches++
+	t.Snatches++
 	return nil
 }
 
 func (c *Conn) MarkActive(t *storage.Torrent) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Active = true
+	t.Active = true
+	return nil
+}
+
+func (c *Conn) MarkInactive(t *storage.Torrent) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Active = false
+	t.Active = false
 	return nil
 }
 
 func (c *Conn) AddLeecher(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Leechers[storage.PeerMapKey(p)] = *p
+	t.Leechers[storage.PeerMapKey(p)] = *p
 	return nil
 }
 
 func (c *Conn) AddSeeder(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Leechers[storage.PeerMapKey(p)] = *p
+	t.Leechers[storage.PeerMapKey(p)] = *p
 	return nil
 }
 
 func (c *Conn) RemoveLeecher(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	delete(torrent.Leechers, storage.PeerMapKey(p))
+	delete(t.Leechers, storage.PeerMapKey(p))
 	return nil
 }
 
 func (c *Conn) RemoveSeeder(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	delete(torrent.Seeders, storage.PeerMapKey(p))
+	delete(t.Seeders, storage.PeerMapKey(p))
 	return nil
 }
 
 func (c *Conn) SetLeecher(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Leechers[storage.PeerMapKey(p)] = *p
+	t.Leechers[storage.PeerMapKey(p)] = *p
 	return nil
 }
 
 func (c *Conn) SetSeeder(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	torrent.Seeders[storage.PeerMapKey(p)] = *p
+	t.Seeders[storage.PeerMapKey(p)] = *p
 	return nil
 }
 
 func (c *Conn) IncrementSlots(u *storage.User) error {
+	c.usersM.Lock()
+	defer c.usersM.Unlock()
+	user, ok := c.users[u.Passkey]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	user.Slots++
+	u.Slots++
 	return nil
 }
 
 func (c *Conn) DecrementSlots(u *storage.User) error {
+	c.usersM.Lock()
+	defer c.usersM.Unlock()
+	user, ok := c.users[u.Passkey]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+	user.Slots--
+	u.Slots--
 	return nil
 }
 
 func (c *Conn) LeecherFinished(t *storage.Torrent, p *storage.Peer) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+
+	torrent, ok := c.torrents[t.Infohash]
+	if !ok {
+		return tracker.ErrMissingResource
+	}
+
+	torrent.Seeders[storage.PeerMapKey(p)] = *p
+	delete(torrent.Leechers, storage.PeerMapKey(p))
+	t.Seeders[storage.PeerMapKey(p)] = *p
+	delete(t.Leechers, storage.PeerMapKey(p))
 	return nil
 }
 
 func (c *Conn) AddTorrent(t *storage.Torrent) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	torrent := *t
+	c.torrents[t.Infohash] = &torrent
 	return nil
 }
 
 func (c *Conn) RemoveTorrent(t *storage.Torrent) error {
+	c.torrentsM.Lock()
+	defer c.torrentsM.Unlock()
+	delete(c.torrents, t.Infohash)
 	return nil
 }
 
 func (c *Conn) AddUser(u *storage.User) error {
+	c.usersM.Lock()
+	defer c.usersM.Unlock()
+	user := *u
+	c.users[u.Passkey] = &user
 	return nil
 }
 
 func (c *Conn) RemoveUser(u *storage.User) error {
+	c.usersM.Lock()
+	defer c.usersM.Unlock()
+	delete(c.users, u.Passkey)
 	return nil
 }
 
 func (c *Conn) WhitelistClient(peerID string) error {
+	c.whitelistM.Lock()
+	defer c.whitelistM.Unlock()
+	c.whitelist[peerID] = true
 	return nil
 }
 
 func (c *Conn) UnWhitelistClient(peerID string) error {
+	c.whitelistM.Lock()
+	defer c.whitelistM.Unlock()
+	delete(c.whitelist, peerID)
 	return nil
 }

--- a/storage/tracker/mock/driver.go
+++ b/storage/tracker/mock/driver.go
@@ -19,6 +19,6 @@ func (d *driver) New(conf *config.DataStore) tracker.Pool {
 	return &Pool{
 		users:     make(map[string]*storage.User),
 		torrents:  make(map[string]*storage.Torrent),
-		whitelist: make(map[string]string),
+		whitelist: make(map[string]bool),
 	}
 }

--- a/storage/tracker/mock/pool.go
+++ b/storage/tracker/mock/pool.go
@@ -18,7 +18,8 @@ type Pool struct {
 	torrents  map[string]*storage.Torrent
 	torrentsM sync.RWMutex
 
-	whitelist map[string]string
+	whitelist  map[string]bool
+	whitelistM sync.RWMutex
 }
 
 func (p *Pool) Get() (tracker.Conn, error) {

--- a/storage/tracker/tracker.go
+++ b/storage/tracker/tracker.go
@@ -7,6 +7,7 @@
 package tracker
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/pushrax/chihaya/config"
@@ -14,7 +15,8 @@ import (
 )
 
 var (
-	drivers = make(map[string]Driver)
+	ErrMissingResource = errors.New("tracker: resource missing")
+	drivers            = make(map[string]Driver)
 )
 
 type Driver interface {
@@ -65,6 +67,7 @@ type Conn interface {
 	// Writes
 	RecordSnatch(u *storage.User, t *storage.Torrent) error
 	MarkActive(t *storage.Torrent) error
+	MarkInactive(t *storage.Torrent) error
 	AddLeecher(t *storage.Torrent, p *storage.Peer) error
 	AddSeeder(t *storage.Torrent, p *storage.Peer) error
 	RemoveLeecher(t *storage.Torrent, p *storage.Peer) error


### PR DESCRIPTION
This PR has three major changes
- storage/tracker exports an ErrMissingResource
- storage/tracker Conn interface now has a MarkInactive method
- storage/tracker/mock is an in-memory implementation of tracker/storage that can be used for testing
