### PR TITLE
Limit number of concurrent connections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	RequestTimeout   Duration `json:"request_timeout"`
 	HttpReadTimeout  Duration `json:"http_read_timeout"`
 	HttpWriteTimeout Duration `json:"http_write_timeout"`
+	HttpListenLimit  int      `json:"http_listen_limit"`
 	NumWantFallback  int      `json:"default_num_want"`
 
 	ClientWhitelistEnabled bool     `json:"client_whitelist_enabled"`

--- a/http/http.go
+++ b/http/http.go
@@ -117,10 +117,14 @@ func Serve(cfg *config.Config, tkr *tracker.Tracker) {
 	}
 
 	glog.V(0).Info("Starting on ", cfg.Addr)
+	if cfg.HttpListenLimit != 0 {
+		glog.V(0).Info("Limiting connections to ", cfg.HttpListenLimit)
+	}
 
 	grace := &graceful.Server{
 		Timeout:   cfg.RequestTimeout.Duration,
 		ConnState: srv.connState,
+		ListenLimit: cfg.HttpListenLimit,
 		Server: &http.Server{
 			Addr:         cfg.Addr,
 			Handler:      newRouter(srv),


### PR DESCRIPTION
Go's net/http library has no limits in place for number of concurrent
requests currently being processed.  This can result in an enormous
number of goroutines being created and the read/write buffer pools
growing unbounded resulting in OOM situations.
