### PR TITLE
Fix IPv4 stats

### DIFF
--- a/tracker/models/models.go
+++ b/tracker/models/models.go
@@ -51,7 +51,11 @@ func NewPeerKey(peerID string, ip net.IP) PeerKey {
 }
 
 func (pk PeerKey) IP() net.IP {
-	return net.ParseIP(strings.Split(string(pk), "//")[1])
+	ip := net.ParseIP(strings.Split(string(pk), "//")[1])
+	if rval := ip.To4(); rval != nil {
+		return rval
+	}
+	return ip
 }
 
 func (pk PeerKey) PeerID() string {


### PR DESCRIPTION
net.ParseIP() will return a v4mapped address which makes len(ip) ==
IPv6len and breaks stats for IPv4 requests.
