### PR TITLE
Remove impossible code for 'completed' event

### DIFF
--- a/tracker/announce.go
+++ b/tracker/announce.go
@@ -230,20 +230,13 @@ func (tkr *Tracker) handlePeerEvent(ann *models.Announce, p *models.Peer) (snatc
 		}
 
 	case ann.Event == "completed":
-		v4seed := t.Seeders.Contains(p.Key())
-		v6seed := t.Seeders.Contains(p.Key())
-
 		if t.Leechers.Contains(p.Key()) {
 			err = tkr.leecherFinished(t, p)
 		} else {
 			err = models.ErrBadRequest
 		}
 
-		// If one of the dual-stacked peers is already a seeder, they have
-		// already snatched.
-		if !(v4seed || v6seed) {
-			snatched = true
-		}
+		snatched = true
 
 	case t.Leechers.Contains(p.Key()) && ann.Left == 0:
 		// A leecher completed but the event was never received.


### PR DESCRIPTION
This code used to work since we could tell if a peer was present in both IP families. We don't have a way to do this now. However, since ba1ad7f5bfadaee6043642bb363c6d7468162a74, it doesn't matter, since line 239 would be hit if `v4seed` or `v6seed` were true and the whole announce will error out.

@jzelinskie does this seem right?