### PR TITLE
tracker: rm badrequest when state is unknown

### DIFF
--- a/tracker/announce.go
+++ b/tracker/announce.go
@@ -155,11 +155,6 @@ func (tkr *Tracker) updatePeer(ann *models.Announce, peer *models.Peer) (created
 		}
 
 	default:
-		if ann.Event != "" && ann.Event != "started" {
-			err = models.ErrBadRequest
-			return
-		}
-
 		if ann.Left == 0 {
 			err = tkr.PutSeeder(t.Infohash, p)
 			if err != nil {


### PR DESCRIPTION
This assumption was just totally wrong. If there is any kind of packet
loss or the tracker starts up to a pre-existing swarm, all the peers
will get bad request responses.