### PR TITLE
Fix Dockerfile to build with the latest changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,24 @@ MAINTAINER Jimmy Zelinskie <jimmyzelinskie@gmail.com>
 # Add files
 WORKDIR        /go/src/github.com/chihaya/chihaya/
 RUN mkdir -p   /go/src/github.com/chihaya/chihaya/
-ADD chihaya.go /go/src/github.com/chihaya/chihaya/
+
+# Dependencies
+RUN go get github.com/tools/godep
+ADD Godeps /go/src/github.com/chihaya/chihaya/Godeps
+RUN godep restore
+
+# Add source
+ADD *.go       /go/src/github.com/chihaya/chihaya/
 ADD backend    /go/src/github.com/chihaya/chihaya/backend
 ADD cmd        /go/src/github.com/chihaya/chihaya/cmd
 ADD config     /go/src/github.com/chihaya/chihaya/config
 ADD http       /go/src/github.com/chihaya/chihaya/http
 ADD stats      /go/src/github.com/chihaya/chihaya/stats
 ADD tracker    /go/src/github.com/chihaya/chihaya/tracker
-ADD Godeps     /go/src/github.com/chihaya/chihaya/Godeps
+ADD udp        /go/src/github.com/chihaya/chihaya/udp
 
 # Install
-RUN go get ./...
-RUN go install
+RUN go install github.com/chihaya/chihaya/cmd/chihaya
 
 # docker run -p 6881:6881 -v $PATH_TO_DIR_WITH_CONF_FILE:/config quay.io/jzelinskie/chihaya
 VOLUME ["/config"]


### PR DESCRIPTION
Things have changed a bit, which broke the Docker build. I also moved dependency fetching to before source addition to prevent the dependency cache from being busted when Chihaya source changes.

@jzelinskie 