### PR TITLE
Fix port overload

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -8,7 +8,7 @@
   "default_num_want": 50,
   "torrent_map_shards": 1,
   "allow_ip_spoofing": true,
-  "dual_stacked_peers": false,
+  "dual_stacked_peers": true,
   "real_ip_header": "",
   "respect_af": false,
   "client_whitelist_enabled": false,

--- a/example_config.json
+++ b/example_config.json
@@ -8,7 +8,7 @@
   "default_num_want": 50,
   "torrent_map_shards": 1,
   "allow_ip_spoofing": true,
-  "dual_stacked_peers": true,
+  "dual_stacked_peers": false,
   "real_ip_header": "",
   "respect_af": false,
   "client_whitelist_enabled": false,

--- a/http/tracker.go
+++ b/http/tracker.go
@@ -171,6 +171,15 @@ func requestedEndpoint(q *query.Query, r *http.Request, cfg *config.NetConfig) (
 		}
 
 		if v4, v6, done = getEndpoints(r.RemoteAddr, v4, v6, cfg); done {
+			// "ip" param is not provided, so we guess IP from HTTP request.
+			// Still we need the port the client listens to, not the source IP
+			// port, used by HTTP request.
+			if v4 != nil {
+				v4.Port = uint16(0)
+			}
+			if v6 != nil {
+				v6.Port = uint16(0)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
I have discovered, that tracker didn't work with ctorrent when using ctorrent with default parameters. Tracker actually worked when IP was forced in ctorrent, so it would send "ip" parameter together with "port". After some debug, I found, that tracker was using port from HTTP request source IP, which was not the port the client was listening to.
After the fix ctorrent was able to work properly.