### PR TITLE
stats: publish last gc PauseNS

### DIFF
--- a/stats/mem.go
+++ b/stats/mem.go
@@ -27,6 +27,7 @@ type BasicMemStats struct {
 
 	// Garbage collector statistics.
 	PauseTotalNs uint64
+	PauseNs      uint64
 }
 
 type memStatsPlaceholder interface{}
@@ -72,5 +73,6 @@ func (s *MemStatsWrapper) Update() {
 		s.basic.HeapReleased = s.cache.HeapReleased
 		s.basic.HeapObjects = s.cache.HeapObjects
 		s.basic.PauseTotalNs = s.cache.PauseTotalNs
+		s.basic.PauseNs = s.cache.PauseNs[(s.cache.NumGC+255)%256]
 	}
 }


### PR DESCRIPTION
Adding GC pause metrics to the stats JSON.

Test plan: looked at `/stats` and verified PauseNs is updated properly. The difference in `PauseTotalNs` from one minute to the next is the same as the most recent `PauseNs`.

```
{
    "BytesTransmitted": 0,
    "Connections.Accepted": 38,
    "Connections.Open": 1,
    "Memory": {
        "Alloc": 534816,
        "Frees": 4452,
        "HeapAlloc": 534816,
        "HeapIdle": 712704,
        "HeapInuse": 991232,
        "HeapObjects": 803,
        "HeapReleased": 0,
        "HeapSys": 1703936,
        "Lookups": 81,
        "Mallocs": 5255,
        "PauseNs": 435248,
        "PauseTotalNs": 3275305,
        "Sys": 3999992,
        "TotalAlloc": 995904
    },
    "Peers.IPv4": {
        "Completed": 0,
        "Peers": {
            "Current": 0,
            "Joined": 0,
            "Left": 0,
            "Reaped": 0
        },
        "Seeds": {
            "Current": 0,
            "Joined": 0,
            "Left": 0,
            "Reaped": 0
        }
    },
    "Peers.IPv6": {
        "Completed": 0,
        "Peers": {
            "Current": 0,
            "Joined": 0,
            "Left": 0,
            "Reaped": 0
        },
        "Seeds": {
            "Current": 0,
            "Joined": 0,
            "Left": 0,
            "Reaped": 0
        }
    },
    "Requests.Bad": 0,
    "Requests.Errored": 0,
    "Requests.Handled": 37,
    "ResponseTime": {
        "P50": 0.082736,
        "P90": 0.102422,
        "P95": 0.118751
    },
    "Runtime.GoRoutines": 17,
    "Started": "2015-08-20T11:44:02.842928389-07:00",
    "Torrents.Added": 0,
    "Torrents.Reaped": 0,
    "Torrents.Removed": 0,
    "Torrents.Size": 0,
    "Tracker.Announces": 0,
    "Tracker.Scrapes": 0
}
```