### PR TITLE
config: make reaping configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,8 @@ type TrackerConfig struct {
 	PurgeInactiveTorrents bool     `json:"purge_inactive_torrents"`
 	Announce              Duration `json:"announce"`
 	MinAnnounce           Duration `json:"min_announce"`
+	ReapInterval          Duration `json:"reap_interval"`
+	ReapRatio             float64  `json:"reap_ratio"`
 	NumWantFallback       int      `json:"default_num_want"`
 	TorrentMapShards      int      `json:"torrent_map_shards"`
 
@@ -121,6 +123,8 @@ var DefaultConfig = Config{
 		PurgeInactiveTorrents: true,
 		Announce:              Duration{30 * time.Minute},
 		MinAnnounce:           Duration{15 * time.Minute},
+		ReapInterval:          Duration{60 * time.Second},
+		ReapRatio:             1.25,
 		NumWantFallback:       50,
 		TorrentMapShards:      1,
 

--- a/example_config.json
+++ b/example_config.json
@@ -5,6 +5,8 @@
   "purge_inactive_torrents": true,
   "announce": "30m",
   "min_announce": "15m",
+  "reap_interval": "60s",
+  "reap_ratio": "1.25",
   "default_num_want": 50,
   "torrent_map_shards": 1,
   "allow_ip_spoofing": true,

--- a/http/announce_test.go
+++ b/http/announce_test.go
@@ -84,9 +84,8 @@ func TestTorrentPurging(t *testing.T) {
 
 func TestStalePeerPurging(t *testing.T) {
 	cfg := config.DefaultConfig
-	cfg.Announce = config.Duration{
-		Duration: 10 * time.Millisecond,
-	}
+	cfg.MinAnnounce = config.Duration{10 * time.Millisecond}
+	cfg.ReapInterval = config.Duration{10 * time.Millisecond}
 
 	srv, err := setupTracker(&cfg)
 	if err != nil {
@@ -110,7 +109,7 @@ func TestStalePeerPurging(t *testing.T) {
 	// Add a leecher.
 	peer2 := makePeerParams("peer2", false)
 	expected := makeResponse(1, 1, peer1)
-	expected["interval"] = int64(0)
+	expected["min interval"] = int64(0)
 	checkAnnounce(peer2, expected, srv, t)
 
 	// Let them both expire.


### PR DESCRIPTION
This allows for configurable reaping rates and changes the default to
what many public trackers use in the wild.