### PR TITLE
backend: remove unused parameter from LoadAllUsers()

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -71,5 +71,5 @@ type Conn interface {
 	LoadUsers(ids []uint64) ([]*models.User, error)
 
 	// LoadAllUsers fetches and returns all users.
-	LoadAllUsers(ids []uint64) ([]*models.User, error)
+	LoadAllUsers() ([]*models.User, error)
 }

--- a/backend/noop/driver.go
+++ b/backend/noop/driver.go
@@ -54,7 +54,7 @@ func (n *NoOp) LoadUsers(ids []uint64) ([]*models.User, error) {
 }
 
 // LoadAllUsers returns (nil, nil).
-func (n *NoOp) LoadAllUsers(ids []uint64) ([]*models.User, error) {
+func (n *NoOp) LoadAllUsers() ([]*models.User, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Fixes #107 

Note: The gazelle driver will have to be updated as well to implement `backend.Conn`, will do that in a minute