### PR TITLE
tracker: update reslicing to use implicit slice bounds

### DIFF
--- a/tracker/models/models.go
+++ b/tracker/models/models.go
@@ -175,7 +175,7 @@ func (a *Announce) ClientID() (clientID string) {
 				clientID = a.PeerID[1:7]
 			}
 		} else {
-			clientID = a.PeerID[0:6]
+			clientID = a.PeerID[:6]
 		}
 	}
 


### PR DESCRIPTION
Fixes #94 

Unfortunately we can not just `go fix` the whole project - I found out that `go fix` only fixes new features for the latest release. Using the `fix` from the go version where implicit slice bounds were introduced will probably not work (because it's ancient).