### PR TITLE
example config: fixed wrong data type for reapRatio

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -6,7 +6,7 @@
   "announce": "30m",
   "minAnnounce": "15m",
   "reapInterval": "60s",
-  "reapRatio": "1.25",
+  "reapRatio": 1.25,
   "defaultNumWant": 50,
   "torrentMapShards": 1,
   "allowIPSpoofing": true,


### PR DESCRIPTION
The string can not be unmarshalled into a `float64`