### PR TITLE
udp: parse URLData according to BEP41

### DIFF
--- a/udp/protocol.go
+++ b/udp/protocol.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chihaya/chihaya/stats"
 	"github.com/chihaya/chihaya/tracker/models"
 	"net/url"
-	"strings"
 )
 
 const (
@@ -253,17 +252,13 @@ func (s *Server) handleOptionalParameters(packet []byte, announce *models.Announ
 func parseQuery(buf *bytes.Buffer, announce *models.Announce) error {
 	if buf.Len() > 0 {
 		s := buf.String()
-		idx := strings.Index(s, "?")
-		if idx != -1 {
-			s := string(buf.Bytes()[idx+1:])
 
-			vals, err := url.ParseQuery(s)
-			if err != nil {
-				return err
-			}
-
-			announce.Passkey = vals.Get("passkey")
+		u, err := url.ParseRequestURI(s)
+		if err != nil {
+			return err
 		}
+
+		announce.Passkey = u.Query().Get("passkey")
 	}
 
 	return nil

--- a/udp/protocol_test.go
+++ b/udp/protocol_test.go
@@ -1,0 +1,60 @@
+package udp
+
+import (
+	"bytes"
+	"github.com/chihaya/chihaya/config"
+	"github.com/chihaya/chihaya/tracker/models"
+	"testing"
+)
+
+func TestParseQuery(t *testing.T) {
+	passkey := "abc123"
+	srv := NewServer(&config.DefaultConfig, nil)
+	ann := &models.Announce{}
+	buf := &bytes.Buffer{}
+	for i := 0; i < 98; i++ {
+		buf.WriteByte(0x1)
+	}
+
+	//now add optional parameters
+	buf.WriteByte(0x2)  //type
+	buf.WriteByte(0x10) //length=16
+	buf.WriteString("/?passkey=")
+	buf.WriteString(passkey)
+
+	err := srv.handleOptionalParameters(buf.Bytes(), ann)
+	if err != nil {
+		t.Fatalf("Error while parsing optional parameters: %s", err)
+	}
+
+	if ann.Passkey != passkey {
+		t.Fatalf("Parsed passkey: %s != %s", ann.Passkey, passkey)
+	}
+}
+
+func TestParseMultipleQuery(t *testing.T) {
+	passkey := "abc123"
+	srv := NewServer(&config.DefaultConfig, nil)
+	ann := &models.Announce{}
+	buf := &bytes.Buffer{}
+	for i := 0; i < 98; i++ {
+		buf.WriteByte(0x1)
+	}
+
+	//now add optional parameters
+	buf.WriteByte(0x2) //type
+	buf.WriteByte(0xA) //length=10
+	buf.WriteString("/?passkey=")
+	buf.WriteByte(0x2) //type
+	buf.WriteByte(0x6) //length=6
+	buf.WriteString(passkey)
+
+	err := srv.handleOptionalParameters(buf.Bytes(), ann)
+	if err != nil {
+		t.Fatalf("Error while handling optional parameters: %s", err)
+	}
+
+	if ann.Passkey != passkey {
+		t.Fatalf("Parsed passkey: %s != %s", ann.Passkey, passkey)
+	}
+}

--- a/udp/protocol_test.go
+++ b/udp/protocol_test.go
@@ -59,7 +59,7 @@ func TestParseMultipleQuery(t *testing.T) {
 	}
 }
 
-func TestURLEncoded(t *testing.T) {
+func TestParseURLEncoded(t *testing.T) {
 	passkey := "abc%20123" //has an URLEncoded space in there
 	srv := NewServer(&config.DefaultConfig, nil)
 	ann := &models.Announce{}

--- a/udp/protocol_test.go
+++ b/udp/protocol_test.go
@@ -58,3 +58,30 @@ func TestParseMultipleQuery(t *testing.T) {
 		t.Fatalf("Parsed passkey: %s != %s", ann.Passkey, passkey)
 	}
 }
+
+func TestURLEncoded(t *testing.T) {
+	passkey := "abc%20123" //has an URLEncoded space in there
+	srv := NewServer(&config.DefaultConfig, nil)
+	ann := &models.Announce{}
+	buf := &bytes.Buffer{}
+	for i := 0; i < 98; i++ {
+		buf.WriteByte(0x1)
+	}
+
+	//now add optional parameters
+	buf.WriteByte(0x2) //type
+	buf.WriteByte(0xA) //length=10
+	buf.WriteString("/?passkey=")
+	buf.WriteByte(0x2) //type
+	buf.WriteByte(0x9) //length=9
+	buf.WriteString(passkey)
+
+	err := srv.handleOptionalParameters(buf.Bytes(), ann)
+	if err != nil {
+		t.Fatalf("Error while handling optional parameters: %s", err)
+	}
+
+	if ann.Passkey != "abc 123" {
+		t.Fatalf("Parsed passkey: %s != %s", ann.Passkey, passkey)
+	}
+}


### PR DESCRIPTION
This is WIP.

I added a first version of URLData optional parameter parsing for UDP announces, as described in [BEP41](http://bittorrent.org/beps/bep_0041.html).

Additionally, I fixed parsing of optional parameters in general, there was a problem with indices, whenever URLData was present and followed by more optional parameters. (see l. 224 in the updated protocol.go)

Now, the only thing I extract from the URLData is the passkey. The problem is: URLData could contain way more than that, but I don't know if we can store that in the announce somehow, or even if we should (think someone sending us bogus parameter strings, we store them in the announce and try to handle them).

Any suggestions? What else could I parse? How to handle more query parameters, e.g. `"/path/something?passkey=abc123"` - what to do with `path` and `something`?

**EDIT**: This somewhat contributes to #53 