### PR TITLE
Moved from glog to logger

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"ImportPath": "github.com/mrd0ll4r/logger",
-			"Rev": "5419e48983b4c5ec72f01aa974cb76df74ea6dc1"
+			"Rev": "33b710fa18d6e0f642a5367cb3b12e07337497e2"
 		},
 		{
 			"ImportPath": "github.com/pushrax/bufferpool",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,18 +1,18 @@
 {
 	"ImportPath": "github.com/chihaya/chihaya",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Deps": [
 		{
 			"ImportPath": "github.com/chihaya/bencode",
 			"Rev": "3c485a8d166ff6a79baba90c2c2da01c8348e930"
 		},
 		{
-			"ImportPath": "github.com/golang/glog",
-			"Rev": "44145f04b68cf362d9c4df2182967c2275eaefed"
-		},
-		{
 			"ImportPath": "github.com/julienschmidt/httprouter",
 			"Rev": "8c199fb6259ffc1af525cc3ad52ee60ba8359669"
+		},
+		{
+			"ImportPath": "github.com/mrd0ll4r/logger",
+			"Rev": "5419e48983b4c5ec72f01aa974cb76df74ea6dc1"
 		},
 		{
 			"ImportPath": "github.com/pushrax/bufferpool",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"ImportPath": "github.com/mrd0ll4r/logger",
-			"Rev": "33b710fa18d6e0f642a5367cb3b12e07337497e2"
+			"Rev": "a8147cde61c12b31f77ef89d079a56101e7febaa"
 		},
 		{
 			"ImportPath": "github.com/pushrax/bufferpool",

--- a/api/api.go
+++ b/api/api.go
@@ -143,19 +143,19 @@ func makeHandler(handler ResponseHandler) httprouter.Handle {
 			stats.RecordEvent(stats.ErroredRequest)
 		}
 
-		if len(msg) > 0 || logger.Logs(logger.LevelDebug) {
+		if len(msg) > 0 || logger.Logs(logger.LevelInfo) {
 			reqString := r.URL.Path + " " + r.RemoteAddr
-			if logger.Logs(logger.LevelTrace) {
+			if logger.Logs(logger.LevelDebug) {
 				reqString = r.URL.RequestURI() + " " + r.RemoteAddr
 			}
 
 			if len(msg) > 0 {
 				logger.Warnf("[API - %9s] %s (%d - %s)", duration, reqString, httpCode, msg)
 			} else {
-				if logger.Logs(logger.LevelTrace) {
-					logger.Tracef("[API - %9s] %s (%d)", duration, reqString, httpCode)
-				} else {
+				if logger.Logs(logger.LevelDebug) {
 					logger.Debugf("[API - %9s] %s (%d)", duration, reqString, httpCode)
+				} else {
+					logger.Infof("[API - %9s] %s (%d)", duration, reqString, httpCode)
 				}
 			}
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -11,13 +11,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/tylerb/graceful"
 
 	"github.com/chihaya/chihaya/config"
 	"github.com/chihaya/chihaya/stats"
 	"github.com/chihaya/chihaya/tracker"
+	"github.com/mrd0ll4r/logger"
 )
 
 // Server represents an API server for a torrent tracker.
@@ -46,10 +46,10 @@ func (s *Server) Stop() {
 
 // Serve runs an API server, blocking until the server has shut down.
 func (s *Server) Serve() {
-	glog.V(0).Info("Starting API on ", s.config.APIConfig.ListenAddr)
+	logger.Infof("Starting API on %s", s.config.APIConfig.ListenAddr)
 
 	if s.config.APIConfig.ListenLimit != 0 {
-		glog.V(0).Info("Limiting connections to ", s.config.APIConfig.ListenLimit)
+		logger.Infof("Limiting connections to %d", s.config.APIConfig.ListenLimit)
 	}
 
 	grace := &graceful.Server{
@@ -72,12 +72,12 @@ func (s *Server) Serve() {
 
 	if err := grace.ListenAndServe(); err != nil {
 		if opErr, ok := err.(*net.OpError); !ok || (ok && opErr.Op != "accept") {
-			glog.Errorf("Failed to gracefully run API server: %s", err.Error())
+			logger.Fatalf("Failed to gracefully run API server: %s", err.Error())
 			return
 		}
 	}
 
-	glog.Info("API server shut down cleanly")
+	logger.Infoln("API server shut down cleanly")
 }
 
 // newRouter returns a router with all the routes.
@@ -116,7 +116,7 @@ func (s *Server) connState(conn net.Conn, state http.ConnState) {
 	case http.StateActive, http.StateIdle:
 
 	default:
-		glog.Errorf("Connection transitioned to unknown state %s (%d)", state, state)
+		logger.Fatalf("Connection transitioned to unknown state %s (%d)", state, state)
 	}
 }
 
@@ -143,16 +143,20 @@ func makeHandler(handler ResponseHandler) httprouter.Handle {
 			stats.RecordEvent(stats.ErroredRequest)
 		}
 
-		if len(msg) > 0 || glog.V(2) {
+		if len(msg) > 0 || logger.Logs(logger.LevelDebug) {
 			reqString := r.URL.Path + " " + r.RemoteAddr
-			if glog.V(3) {
+			if logger.Logs(logger.LevelTrace) {
 				reqString = r.URL.RequestURI() + " " + r.RemoteAddr
 			}
 
 			if len(msg) > 0 {
-				glog.Errorf("[API - %9s] %s (%d - %s)", duration, reqString, httpCode, msg)
+				logger.Warnf("[API - %9s] %s (%d - %s)", duration, reqString, httpCode, msg)
 			} else {
-				glog.Infof("[API - %9s] %s (%d)", duration, reqString, httpCode)
+				if logger.Logs(logger.LevelTrace) {
+					logger.Tracef("[API - %9s] %s (%d)", duration, reqString, httpCode)
+				} else {
+					logger.Debugf("[API - %9s] %s (%d)", duration, reqString, httpCode)
+				}
 			}
 		}
 

--- a/chihaya.go
+++ b/chihaya.go
@@ -14,8 +14,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
-
-	"github.com/golang/glog"
+	"log"
 
 	"github.com/chihaya/chihaya/api"
 	"github.com/chihaya/chihaya/config"
@@ -23,16 +22,22 @@ import (
 	"github.com/chihaya/chihaya/stats"
 	"github.com/chihaya/chihaya/tracker"
 	"github.com/chihaya/chihaya/udp"
+
+	"github.com/mrd0ll4r/logger"
 )
 
 var (
-	maxProcs   int
-	configPath string
+	maxProcs        int
+	configPath      string
+	logLevel        int
+	logFileLocation bool
 )
 
 func init() {
 	flag.IntVar(&maxProcs, "maxprocs", runtime.NumCPU(), "maximum parallel threads")
 	flag.StringVar(&configPath, "config", "", "path to the configuration file")
+	flag.IntVar(&logLevel, "level", int(logger.LevelInfo), "level of logging, where 0=Everything, 1=Trace, 2=Debug, 3=Info, 4=Warnings, 5=Fatal")
+	flag.BoolVar(&logFileLocation, "logLocation", false, "whether to log file locations")
 }
 
 type server interface {
@@ -43,32 +48,49 @@ type server interface {
 // Boot starts Chihaya. By exporting this function, anyone can import their own
 // custom drivers into their own package main and then call chihaya.Boot.
 func Boot() {
-	defer glog.Flush()
-
 	flag.Parse()
 
+	l := logger.NewStdlibLogger()
+	if logFileLocation {
+		l.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
+	} else {
+		l.SetFlags(log.Lmicroseconds | log.Ldate)
+	}
+
+	level := logger.LogLevel(logLevel)
+
+	if level < logger.Everything || level >= logger.Off {
+		l.Fatalln("Invalid log level")
+	}
+	l.SetLevel(level)
+
+	// we have to do this to use the short functions like logger.Infoln
+	l.SetCalldepthForDefault()
+
+	logger.SetDefaultLogger(l)
+
 	runtime.GOMAXPROCS(maxProcs)
-	glog.V(1).Info("Set max threads to ", maxProcs)
+	logger.Debugf("Set max threads to %d", maxProcs)
 
 	debugBoot()
 	defer debugShutdown()
 
 	cfg, err := config.Open(configPath)
 	if err != nil {
-		glog.Fatalf("Failed to parse configuration file: %s\n", err)
+		logger.Fatalf("Failed to parse configuration file: %s", err)
 	}
 
 	if cfg == &config.DefaultConfig {
-		glog.V(1).Info("Using default config")
+		logger.Infoln("Using default config")
 	} else {
-		glog.V(1).Infof("Loaded config file: %s", configPath)
+		logger.Infof("Loaded config file %s", configPath)
 	}
 
 	stats.DefaultStats = stats.New(cfg.StatsConfig)
 
 	tkr, err := tracker.New(cfg)
 	if err != nil {
-		glog.Fatal("New: ", err)
+		logger.Fatalln("Unable to create new tracker:", err)
 	}
 
 	var servers []server
@@ -107,7 +129,7 @@ func Boot() {
 	}()
 
 	<-shutdown
-	glog.Info("Shutting down...")
+	logger.Infoln("Shutting down...")
 
 	for _, srv := range servers {
 		srv.Stop()
@@ -116,6 +138,6 @@ func Boot() {
 	<-shutdown
 
 	if err := tkr.Close(); err != nil {
-		glog.Errorf("Failed to shut down tracker cleanly: %s", err.Error())
+		logger.Warnf("Failed to shut down tracker cleanly: %s", err.Error())
 	}
 }

--- a/chihaya.go
+++ b/chihaya.go
@@ -29,14 +29,14 @@ import (
 var (
 	maxProcs        int
 	configPath      string
-	logLevel        int
+	logLevel        string
 	logFileLocation bool
 )
 
 func init() {
 	flag.IntVar(&maxProcs, "maxprocs", runtime.NumCPU(), "maximum parallel threads")
 	flag.StringVar(&configPath, "config", "", "path to the configuration file")
-	flag.IntVar(&logLevel, "level", int(logger.LevelInfo), "level of logging, where 0=Everything, 1=Trace, 2=Debug, 3=Info, 4=Warnings, 5=Fatal")
+	flag.StringVar(&logLevel, "level", "info", "level of logging (everything, trace, debug, info, warn, fatal), everything above and including will be logged")
 	flag.BoolVar(&logFileLocation, "logLocation", false, "whether to log file locations")
 }
 
@@ -57,11 +57,16 @@ func Boot() {
 		l.SetFlags(log.Lmicroseconds | log.Ldate)
 	}
 
-	level := logger.LogLevel(logLevel)
-
-	if level < logger.Everything || level >= logger.Off {
-		l.Fatalln("Invalid log level")
+	level, err := logger.ByName(logLevel)
+	if err != nil {
+		flag.Usage()
+		l.Fatalln("Unkown level of logging")
 	}
+
+	if level == logger.Everything {
+		l.SetFlags(log.Lshortfile | log.Lmicroseconds | log.Ldate)
+	}
+
 	l.SetLevel(level)
 
 	// we have to do this to use the short functions like logger.Infoln

--- a/debug.go
+++ b/debug.go
@@ -10,9 +10,8 @@ import (
 	"os"
 	"runtime/pprof"
 
+	"github.com/mrd0ll4r/logger"
 	_ "net/http/pprof"
-
-	"github.com/golang/glog"
 )
 
 var (
@@ -31,19 +30,19 @@ func debugBoot() {
 
 	if debugAddr != "" {
 		go func() {
-			glog.Info("Starting debug HTTP on ", debugAddr)
-			glog.Fatal(http.ListenAndServe(debugAddr, nil))
+			logger.Infof("Starting debug HTTP on %s", debugAddr)
+			logger.Fatalln(http.ListenAndServe(debugAddr, nil))
 		}()
 	}
 
 	if profile != "" {
 		profileFile, err = os.Create(profile)
 		if err != nil {
-			glog.Fatalf("Failed to create profile file: %s\n", err)
+			logger.Fatalf("Failed to create profile file: %s", err)
 		}
 
 		pprof.StartCPUProfile(profileFile)
-		glog.Info("Started profiling")
+		logger.Infoln("Started profiling")
 	}
 }
 
@@ -51,6 +50,6 @@ func debugShutdown() {
 	if profileFile != nil {
 		profileFile.Close()
 		pprof.StopCPUProfile()
-		glog.Info("Stopped profiling")
+		logger.Infoln("Stopped profiling")
 	}
 }

--- a/http/http.go
+++ b/http/http.go
@@ -51,19 +51,19 @@ func makeHandler(handler ResponseHandler) httprouter.Handle {
 			stats.RecordEvent(stats.ErroredRequest)
 		}
 
-		if len(msg) > 0 || logger.Logs(logger.LevelDebug) {
+		if len(msg) > 0 || logger.Logs(logger.LevelInfo) {
 			reqString := r.URL.Path + " " + r.RemoteAddr
-			if logger.Logs(logger.LevelTrace) {
+			if logger.Logs(logger.LevelDebug) {
 				reqString = r.URL.RequestURI() + " " + r.RemoteAddr
 			}
 
 			if len(msg) > 0 {
 				logger.Warnf("[HTTP - %9s] %s (%d - %s)", duration, reqString, httpCode, msg)
 			} else {
-				if logger.Logs(logger.LevelTrace) {
-					logger.Tracef("[HTTP - %9s] %s (%d)", duration, reqString, httpCode)
-				} else {
+				if logger.Logs(logger.LevelDebug) {
 					logger.Debugf("[HTTP - %9s] %s (%d)", duration, reqString, httpCode)
+				} else {
+					logger.Infof("[HTTP - %9s] %s (%d)", duration, reqString, httpCode)
 				}
 			}
 		}

--- a/http/http.go
+++ b/http/http.go
@@ -11,13 +11,13 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/tylerb/graceful"
 
 	"github.com/chihaya/chihaya/config"
 	"github.com/chihaya/chihaya/stats"
 	"github.com/chihaya/chihaya/tracker"
+	"github.com/mrd0ll4r/logger"
 )
 
 // ResponseHandler is an HTTP handler that returns a status code.
@@ -51,16 +51,20 @@ func makeHandler(handler ResponseHandler) httprouter.Handle {
 			stats.RecordEvent(stats.ErroredRequest)
 		}
 
-		if len(msg) > 0 || glog.V(2) {
+		if len(msg) > 0 || logger.Logs(logger.LevelDebug) {
 			reqString := r.URL.Path + " " + r.RemoteAddr
-			if glog.V(3) {
+			if logger.Logs(logger.LevelTrace) {
 				reqString = r.URL.RequestURI() + " " + r.RemoteAddr
 			}
 
 			if len(msg) > 0 {
-				glog.Errorf("[HTTP - %9s] %s (%d - %s)", duration, reqString, httpCode, msg)
+				logger.Warnf("[HTTP - %9s] %s (%d - %s)", duration, reqString, httpCode, msg)
 			} else {
-				glog.Infof("[HTTP - %9s] %s (%d)", duration, reqString, httpCode)
+				if logger.Logs(logger.LevelTrace) {
+					logger.Tracef("[HTTP - %9s] %s (%d)", duration, reqString, httpCode)
+				} else {
+					logger.Debugf("[HTTP - %9s] %s (%d)", duration, reqString, httpCode)
+				}
 			}
 		}
 
@@ -96,16 +100,16 @@ func (s *Server) connState(conn net.Conn, state http.ConnState) {
 	case http.StateActive, http.StateIdle:
 
 	default:
-		glog.Errorf("Connection transitioned to unknown state %s (%d)", state, state)
+		logger.Fatalf("Connection transitioned to unknown state %s (%d)", state, state)
 	}
 }
 
 // Serve runs an HTTP server, blocking until the server has shut down.
 func (s *Server) Serve() {
-	glog.V(0).Info("Starting HTTP on ", s.config.HTTPConfig.ListenAddr)
+	logger.Infof("Starting HTTP on %s", s.config.HTTPConfig.ListenAddr)
 
 	if s.config.HTTPConfig.ListenLimit != 0 {
-		glog.V(0).Info("Limiting connections to ", s.config.HTTPConfig.ListenLimit)
+		logger.Infof("Limiting connections to %d", s.config.HTTPConfig.ListenLimit)
 	}
 
 	grace := &graceful.Server{
@@ -128,12 +132,12 @@ func (s *Server) Serve() {
 
 	if err := grace.ListenAndServe(); err != nil {
 		if opErr, ok := err.(*net.OpError); !ok || (ok && opErr.Op != "accept") {
-			glog.Errorf("Failed to gracefully run HTTP server: %s", err.Error())
+			logger.Fatalf("Failed to gracefully run HTTP server: %s", err.Error())
 			return
 		}
 	}
 
-	glog.Info("HTTP server shut down cleanly")
+	logger.Infoln("HTTP server shut down cleanly")
 }
 
 // Stop cleanly shuts down the server.

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -9,10 +9,10 @@ package tracker
 import (
 	"time"
 
-	"github.com/golang/glog"
-
 	"github.com/chihaya/chihaya/config"
 	"github.com/chihaya/chihaya/tracker/models"
+	
+	"github.com/mrd0ll4r/logger"
 )
 
 // Tracker represents the logic necessary to service BitTorrent announces,
@@ -75,11 +75,11 @@ type Writer interface {
 func (tkr *Tracker) purgeInactivePeers(purgeEmptyTorrents bool, threshold, interval time.Duration) {
 	for _ = range time.NewTicker(interval).C {
 		before := time.Now().Add(-threshold)
-		glog.V(0).Infof("Purging peers with no announces since %s", before)
+		logger.Infof("Purging peers with no announces since %s", before)
 
 		err := tkr.PurgeInactivePeers(purgeEmptyTorrents, before)
 		if err != nil {
-			glog.Errorf("Error purging torrents: %s", err)
+			logger.Warnf("Error purging torrents: %s", err)
 		}
 	}
 }

--- a/udp/udp.go
+++ b/udp/udp.go
@@ -12,11 +12,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/pushrax/bufferpool"
 
 	"github.com/chihaya/chihaya/config"
 	"github.com/chihaya/chihaya/tracker"
+	"github.com/mrd0ll4r/logger"
 )
 
 // Server represents a UDP torrent tracker.
@@ -87,12 +87,10 @@ func (s *Server) serve() error {
 				sock.WriteToUDP(response, addr)
 			}
 
-			if glog.V(2) {
-				if err != nil {
-					glog.Infof("[UDP - %9s] %s %s (%s)", duration, action, addr, err)
-				} else {
-					glog.Infof("[UDP - %9s] %s %s", duration, action, addr)
-				}
+			if err != nil {
+				logger.Warnf("[UDP - %9s] %s %s (%s)", duration, action, addr, err)
+			} else {
+				logger.Debugf("[UDP - %9s] %s %s", duration, action, addr)
 			}
 		}()
 	}
@@ -102,7 +100,7 @@ func (s *Server) serve() error {
 
 // Serve runs a UDP server, blocking until the server has shut down.
 func (s *Server) Serve() {
-	glog.V(0).Info("Starting UDP on ", s.config.UDPConfig.ListenAddr)
+	logger.Infof("Starting UDP on %s", s.config.UDPConfig.ListenAddr)
 
 	s.wg.Add(1)
 	go func() {
@@ -120,9 +118,9 @@ func (s *Server) Serve() {
 	}()
 
 	if err := s.serve(); err != nil {
-		glog.Errorf("Failed to run UDP server: %s", err.Error())
+		logger.Fatalf("Failed to run UDP server: %s", err.Error())
 	} else {
-		glog.Info("UDP server shut down cleanly")
+		logger.Infoln("UDP server shut down cleanly")
 	}
 }
 

--- a/udp/udp.go
+++ b/udp/udp.go
@@ -90,7 +90,7 @@ func (s *Server) serve() error {
 			if err != nil {
 				logger.Warnf("[UDP - %9s] %s %s (%s)", duration, action, addr, err)
 			} else {
-				logger.Debugf("[UDP - %9s] %s %s", duration, action, addr)
+				logger.Infof("[UDP - %9s] %s %s", duration, action, addr)
 			}
 		}()
 	}


### PR DESCRIPTION
This somewhat contributes to #44.

Note that logger does not (yet?) support mapping some log events to special outputs (i.e. `stderr`), so now everything just logs to `stdout` by default.