### PR TITLE
Hotfix configparse

### DIFF
--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -15,8 +15,11 @@ import (
 	"github.com/chihaya/chihaya/server"
 	"github.com/chihaya/chihaya/tracker"
 
-	_ "github.com/chihaya/chihaya/server/store/middleware/ip"
 	_ "github.com/chihaya/chihaya/server/http"
+	_ "github.com/chihaya/chihaya/server/store"
+	_ "github.com/chihaya/chihaya/server/store/memory"
+	_ "github.com/chihaya/chihaya/server/store/middleware/client"
+	_ "github.com/chihaya/chihaya/server/store/middleware/ip"
 )
 
 var configPath string

--- a/server/http/config.go
+++ b/server/http/config.go
@@ -7,6 +7,7 @@ package http
 import (
 	"time"
 
+	"github.com/chihaya/chihaya/config"
 	"gopkg.in/yaml.v2"
 )
 
@@ -20,8 +21,8 @@ type httpConfig struct {
 	RealIPHeader     string        `yaml:"real_ip_header"`
 }
 
-func newHTTPConfig(srvcfg interface{}) (*httpConfig, error) {
-	bytes, err := yaml.Marshal(srvcfg)
+func newHTTPConfig(srvcfg *config.ServerConfig) (*httpConfig, error) {
+	bytes, err := yaml.Marshal(srvcfg.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -79,6 +79,8 @@ func (s *httpServer) Start() {
 			return
 		}
 	}
+
+	log.Println("HTTP server shut down cleanly")
 }
 
 func (s *httpServer) Stop() {

--- a/server/pool.go
+++ b/server/pool.go
@@ -20,8 +20,7 @@ type Pool struct {
 // StartPool creates a new pool of servers specified by the provided config and
 // runs them.
 func StartPool(cfgs []config.ServerConfig, tkr *tracker.Tracker) (*Pool, error) {
-	var servers []Server
-	var wg sync.WaitGroup
+	var toReturn Pool
 
 	for _, cfg := range cfgs {
 		srv, err := New(&cfg, tkr)
@@ -29,19 +28,16 @@ func StartPool(cfgs []config.ServerConfig, tkr *tracker.Tracker) (*Pool, error) 
 			return nil, err
 		}
 
-		wg.Add(1)
+		toReturn.wg.Add(1)
 		go func(srv Server) {
-			defer wg.Done()
+			defer toReturn.wg.Done()
 			srv.Start()
 		}(srv)
 
-		servers = append(servers, srv)
+		toReturn.servers = append(toReturn.servers, srv)
 	}
 
-	return &Pool{
-		servers: servers,
-		wg:      wg,
-	}, nil
+	return &toReturn, nil
 }
 
 // Stop safely shuts down a pool of servers.

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -48,6 +48,7 @@ func constructor(srvcfg *config.ServerConfig, tkr *tracker.Tracker) (server.Serv
 		theStore = &Store{
 			cfg:         cfg,
 			tkr:         tkr,
+			shutdown:    make(chan struct{}),
 			ClientStore: cs,
 			PeerStore:   ps,
 			IPStore:     ips,

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -70,8 +70,8 @@ type Config struct {
 	IPStoreConfig     interface{}   `yaml:"ip_store_config"`
 }
 
-func newConfig(srvcfg interface{}) (*Config, error) {
-	bytes, err := yaml.Marshal(srvcfg)
+func newConfig(srvcfg *config.ServerConfig) (*Config, error) {
+	bytes, err := yaml.Marshal(srvcfg.Config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This
 - fixes config parsing for both the store and the http server
 - fixes synchronization when shutting down the pool
 - adds a log line indicating the HTTP server has been shut down cleanly
 - adds dependencies to cmd/chihaya, so that more shipped modules are built