### PR TITLE
tracker: added a way for middleware constructors to fail

### DIFF
--- a/tracker/middleware.go
+++ b/tracker/middleware.go
@@ -16,7 +16,7 @@ type AnnounceMiddleware func(AnnounceHandler) AnnounceHandler
 
 // AnnounceMiddlewareConstructor is a function that creates a new
 // AnnounceMiddleware from a MiddlewareConfig.
-type AnnounceMiddlewareConstructor func(chihaya.MiddlewareConfig) AnnounceMiddleware
+type AnnounceMiddlewareConstructor func(chihaya.MiddlewareConfig) (AnnounceMiddleware, error)
 
 type announceChain struct{ mw []AnnounceMiddleware }
 
@@ -65,8 +65,8 @@ func RegisterAnnounceMiddleware(name string, mw AnnounceMiddleware) {
 		panic("tracker: could not register nil AnnounceMiddleware")
 	}
 
-	RegisterAnnounceMiddlewareConstructor(name, func(_ chihaya.MiddlewareConfig) AnnounceMiddleware {
-		return mw
+	RegisterAnnounceMiddlewareConstructor(name, func(_ chihaya.MiddlewareConfig) (AnnounceMiddleware, error) {
+		return mw, nil
 	})
 }
 
@@ -80,7 +80,7 @@ type ScrapeMiddleware func(ScrapeHandler) ScrapeHandler
 
 // ScrapeMiddlewareConstructor is a function that creates a new
 // ScrapeMiddleware from a MiddlewareConfig.
-type ScrapeMiddlewareConstructor func(chihaya.MiddlewareConfig) ScrapeMiddleware
+type ScrapeMiddlewareConstructor func(chihaya.MiddlewareConfig) (ScrapeMiddleware, error)
 
 type scrapeChain struct{ mw []ScrapeMiddleware }
 
@@ -128,7 +128,7 @@ func RegisterScrapeMiddleware(name string, mw ScrapeMiddleware) {
 		panic("tracker: could not register nil ScrapeMiddleware")
 	}
 
-	RegisterScrapeMiddlewareConstructor(name, func(_ chihaya.MiddlewareConfig) ScrapeMiddleware {
-		return mw
+	RegisterScrapeMiddlewareConstructor(name, func(_ chihaya.MiddlewareConfig) (ScrapeMiddleware, error) {
+		return mw, nil
 	})
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -9,6 +9,7 @@ package tracker
 import (
 	"errors"
 
+	"fmt"
 	"github.com/chihaya/chihaya"
 )
 
@@ -36,7 +37,11 @@ func NewTracker(cfg *chihaya.TrackerConfig) (*Tracker, error) {
 		if !ok {
 			return nil, errors.New("failed to find announce middleware: " + mwConfig.Name)
 		}
-		achain.Append(mw(mwConfig))
+		middleware, err := mw(mwConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load announce middleware %q: %s", mwConfig.Name, err.Error())
+		}
+		achain.Append(middleware)
 	}
 
 	var schain scrapeChain
@@ -45,7 +50,11 @@ func NewTracker(cfg *chihaya.TrackerConfig) (*Tracker, error) {
 		if !ok {
 			return nil, errors.New("failed to find scrape middleware: " + mwConfig.Name)
 		}
-		schain.Append(mw(mwConfig))
+		middleware, err := mw(mwConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load scrape middleware %q: %s", mwConfig.Name, err.Error())
+		}
+		schain.Append(middleware)
 	}
 
 	return &Tracker{


### PR DESCRIPTION
If for example the config is invalid, a *MiddlewareConstructor should be able to fail without panicking