### PR TITLE
http: stopped throwing error on invalid event

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 # This is the official list of Chihaya contributors, in alphabetical order.
 
 Jimmy Zelinskie <jimmyzelinskie@gmail.com>
+Josh de Kock <josh@itanimul.li>
 Justin Li <jli@j-li.net>
 Leo Balduf <balduf@hm.edu>

--- a/server/http/request.go
+++ b/server/http/request.go
@@ -23,8 +23,10 @@ func announceRequest(r *http.Request, cfg *httpConfig) (*chihaya.AnnounceRequest
 	request := &chihaya.AnnounceRequest{Params: q}
 
 	eventStr, err := q.String("event")
-	if err != nil {
-		eventStr = "none"
+	if err == query.ErrKeyNotFound {
+		eventStr = ""
+	} else if err != nil {
+		return nil, tracker.ClientError("failed to parse parameter: event")
 	}
 	request.Event, err = event.New(eventStr)
 	if err != nil {

--- a/server/http/request.go
+++ b/server/http/request.go
@@ -24,7 +24,7 @@ func announceRequest(r *http.Request, cfg *httpConfig) (*chihaya.AnnounceRequest
 
 	eventStr, err := q.String("event")
 	if err != nil {
-		return nil, tracker.ClientError("failed to parse parameter: event")
+		eventStr = "none"
 	}
 	request.Event, err = event.New(eventStr)
 	if err != nil {


### PR DESCRIPTION
Event is an optional key, and if it's invalid or non-existent then it can just be assumed as 'none'.