### PR TITLE
more general interfaces

### DIFF
--- a/pkg/bencode/decoder.go
+++ b/pkg/bencode/decoder.go
@@ -113,7 +113,7 @@ func unmarshal(r *bufio.Reader) (interface{}, error) {
 	}
 }
 
-func readTerminator(r *bufio.Reader, term byte) (bool, error) {
+func readTerminator(r io.ByteScanner, term byte) (bool, error) {
 	tok, err := r.ReadByte()
 	if err != nil {
 		return false, err

--- a/server/http/request.go
+++ b/server/http/request.go
@@ -106,23 +106,23 @@ func scrapeRequest(r *http.Request, cfg *httpConfig) (*chihaya.ScrapeRequest, er
 
 // requestedIP returns the IP address for a request. If there are multiple in
 // the request, one IPv4 and one IPv6 will be returned.
-func requestedIP(q *query.Query, r *http.Request, cfg *httpConfig) (v4, v6 net.IP, err error) {
+func requestedIP(p chihaya.Params, r *http.Request, cfg *httpConfig) (v4, v6 net.IP, err error) {
 	var done bool
 
 	if cfg.AllowIPSpoofing {
-		if str, e := q.String("ip"); e == nil {
+		if str, e := p.String("ip"); e == nil {
 			if v4, v6, done = getIPs(str, v4, v6, cfg); done {
 				return
 			}
 		}
 
-		if str, e := q.String("ipv4"); e == nil {
+		if str, e := p.String("ipv4"); e == nil {
 			if v4, v6, done = getIPs(str, v4, v6, cfg); done {
 				return
 			}
 		}
 
-		if str, e := q.String("ipv6"); e == nil {
+		if str, e := p.String("ipv6"); e == nil {
 			if v4, v6, done = getIPs(str, v4, v6, cfg); done {
 				return
 			}


### PR DESCRIPTION
Fixes #156.

We could later expand this to make all the current methods in `http/request.go` use `chihaya.Params` and wrap them with a method that specifically uses the `query` package.