### PR TITLE
Lint, vet, Start/Stop

### DIFF
--- a/chihaya.go
+++ b/chihaya.go
@@ -11,7 +11,10 @@ import (
 	"github.com/chihaya/chihaya/pkg/event"
 )
 
+// PeerID represents a peer ID.
 type PeerID string
+
+// InfoHash represents an infohash in hexadecimal notation.
 type InfoHash string
 
 // AnnounceRequest represents the parsed parameters from an announce request.

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -40,6 +40,9 @@ type httpServer struct {
 	grace *graceful.Server
 }
 
+// Start runs the server and blocks until it has exited.
+//
+// It panics if the server exits unexpectedly.
 func (s *httpServer) Start() {
 	s.grace = &graceful.Server{
 		Server: &http.Server{
@@ -81,6 +84,7 @@ func (s *httpServer) Start() {
 	log.Println("HTTP server shut down cleanly")
 }
 
+// Stop stops the server and blocks until the server has exited.
 func (s *httpServer) Stop() {
 	s.grace.Stop(s.grace.Timeout)
 	<-s.grace.StopChan()

--- a/server/prometheus/prometheus.go
+++ b/server/prometheus/prometheus.go
@@ -71,6 +71,9 @@ type Server struct {
 
 var _ server.Server = &Server{}
 
+// Start starts the prometheus server and blocks until it exits.
+//
+// It panics if the server exits unexpectedly.
 func (s *Server) Start() {
 	s.grace = &graceful.Server{
 		Server: &http.Server{
@@ -93,6 +96,7 @@ func (s *Server) Start() {
 	log.Println("Prometheus server shut down cleanly")
 }
 
+// Stop stops the prometheus server and blocks until it exits.
 func (s *Server) Stop() {
 	s.grace.Stop(s.cfg.ShutdownTimeout)
 	<-s.grace.StopChan()

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,11 @@ func New(cfg *chihaya.ServerConfig, tkr *tracker.Tracker) (Server, error) {
 
 // Server represents one instance of a server accessing the tracker.
 type Server interface {
+	// Start starts a server and blocks until the server exits.
+	//
+	// It should panic if the server exits unexpectedly.
 	Start()
+
+	// Stop stops a server and blocks until the server exits.
 	Stop()
 }

--- a/server/store/memory/peer_store_test.go
+++ b/server/store/memory/peer_store_test.go
@@ -50,8 +50,8 @@ func TestPeerStoreAPI(t *testing.T) {
 			1,
 		}
 		config = store.DriverConfig{
-			"memory",
-			unmarshalledConfig,
+			Name:   "memory",
+			Config: unmarshalledConfig,
 		}
 		d = &peerStoreDriver{}
 	)
@@ -62,9 +62,9 @@ func TestPeerStoreAPI(t *testing.T) {
 	for _, p := range peers {
 		// Construct chihaya.Peer from test data.
 		peer := chihaya.Peer{
-			chihaya.PeerID(p.peerID),
-			net.ParseIP(p.ip),
-			p.port,
+			ID:   chihaya.PeerID(p.peerID),
+			IP:   net.ParseIP(p.ip),
+			Port: p.port,
 		}
 
 		if p.seeder {
@@ -95,9 +95,9 @@ func TestPeerStoreAPI(t *testing.T) {
 	for _, p := range peers {
 		// Construct chihaya.Peer from test data.
 		peer := chihaya.Peer{
-			chihaya.PeerID(p.peerID),
-			net.ParseIP(p.ip),
-			p.port,
+			ID:   chihaya.PeerID(p.peerID),
+			IP:   net.ParseIP(p.ip),
+			Port: p.port,
 		}
 
 		if p.seeder {
@@ -121,9 +121,9 @@ func TestPeerStoreAPI(t *testing.T) {
 	for _, p := range peers {
 		// Construct chihaya.Peer from test data.
 		peer := chihaya.Peer{
-			chihaya.PeerID(p.peerID),
-			net.ParseIP(p.ip),
-			p.port,
+			ID:   chihaya.PeerID(p.peerID),
+			IP:   net.ParseIP(p.ip),
+			Port: p.port,
 		}
 		if p.seeder {
 			s.PutSeeder(hash, peer)
@@ -136,9 +136,9 @@ func TestPeerStoreAPI(t *testing.T) {
 	assert.Equal(t, 6, s.NumSeeders(hash))
 	assert.Equal(t, 4, s.NumLeechers(hash))
 	peer := chihaya.Peer{
-		chihaya.PeerID(peers[0].peerID),
-		net.ParseIP(peers[0].ip),
-		peers[0].port,
+		ID:   chihaya.PeerID(peers[0].peerID),
+		IP:   net.ParseIP(peers[0].ip),
+		Port: peers[0].port,
 	}
 	err = s.GraduateLeecher(hash, peer)
 	assert.Nil(t, err)

--- a/server/store/middleware/infohash/whitelist.go
+++ b/server/store/middleware/infohash/whitelist.go
@@ -6,7 +6,6 @@ package infohash
 
 import (
 	"github.com/chihaya/chihaya"
-	"github.com/chihaya/chihaya/server/store"
 	"github.com/chihaya/chihaya/tracker"
 )
 
@@ -22,7 +21,7 @@ const PrefixInfohash = "ih-"
 // for infohashes that are not stored in a StringStore
 func whitelistAnnounceInfohash(next tracker.AnnounceHandler) tracker.AnnounceHandler {
 	return func(cfg *chihaya.TrackerConfig, req *chihaya.AnnounceRequest, resp *chihaya.AnnounceResponse) (err error) {
-		whitelisted, err := store.MustGetStore().HasString(PrefixInfohash + string(req.InfoHash))
+		whitelisted, err := mustGetStore().HasString(PrefixInfohash + string(req.InfoHash))
 
 		if err != nil {
 			return err
@@ -62,7 +61,7 @@ func whitelistScrapeInfohash(c chihaya.MiddlewareConfig) (tracker.ScrapeMiddlewa
 func whitelistFilterScrape(next tracker.ScrapeHandler) tracker.ScrapeHandler {
 	return func(cfg *chihaya.TrackerConfig, req *chihaya.ScrapeRequest, resp *chihaya.ScrapeResponse) (err error) {
 		whitelisted := false
-		storage := store.MustGetStore()
+		storage := mustGetStore()
 		infohashes := req.InfoHashes
 
 		for i, ih := range infohashes {
@@ -83,7 +82,7 @@ func whitelistFilterScrape(next tracker.ScrapeHandler) tracker.ScrapeHandler {
 func whitelistBlockScrape(next tracker.ScrapeHandler) tracker.ScrapeHandler {
 	return func(cfg *chihaya.TrackerConfig, req *chihaya.ScrapeRequest, resp *chihaya.ScrapeResponse) (err error) {
 		whitelisted := false
-		storage := store.MustGetStore()
+		storage := mustGetStore()
 
 		for _, ih := range req.InfoHashes {
 			whitelisted, err = storage.HasString(PrefixInfohash + string(ih))

--- a/server/store/middleware/infohash/whitelist_test.go
+++ b/server/store/middleware/infohash/whitelist_test.go
@@ -94,7 +94,3 @@ func TestWhitelistScrapeMiddlewareFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []chihaya.InfoHash{chihaya.InfoHash("abc")}, req.InfoHashes)
 }
-
-func TestZTearDown(t *testing.T) {
-	srv.Stop()
-}

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -111,6 +111,9 @@ type Store struct {
 }
 
 func (s *Store) Start() {
+	<-s.shutdown
+	s.wg.Wait()
+	log.Println("Store server shut down cleanly")
 }
 
 func (s *Store) Stop() {

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -57,6 +57,7 @@ func constructor(srvcfg *chihaya.ServerConfig, tkr *tracker.Tracker) (server.Ser
 	return theStore, nil
 }
 
+// Config represents the configuration for the store.
 type Config struct {
 	Addr           string        `yaml:"addr"`
 	RequestTimeout time.Duration `yaml:"request_timeout"`
@@ -68,6 +69,7 @@ type Config struct {
 	StringStore    DriverConfig  `yaml:"string_store"`
 }
 
+// DriverConfig represents the configuration for a store driver.
 type DriverConfig struct {
 	Name   string      `yaml:"name"`
 	Config interface{} `yaml:"config"`
@@ -99,6 +101,7 @@ func MustGetStore() *Store {
 	return theStore
 }
 
+// Store provides storage for a tracker.
 type Store struct {
 	cfg      *Config
 	tkr      *tracker.Tracker
@@ -110,12 +113,14 @@ type Store struct {
 	StringStore
 }
 
+// Start starts the store drivers and blocks until all of them exit.
 func (s *Store) Start() {
 	<-s.shutdown
 	s.wg.Wait()
 	log.Println("Store server shut down cleanly")
 }
 
+// Stop stops the store drivers and waits for them to exit.
 func (s *Store) Stop() {
 	close(s.shutdown)
 	s.wg.Wait()

--- a/server/store/string_store.go
+++ b/server/store/string_store.go
@@ -16,7 +16,7 @@ type StringStore interface {
 }
 
 // StringStoreDriver represents an interface for creating a handle to the
-// storage of swarms.
+// storage of strings.
 type StringStoreDriver interface {
 	New(*DriverConfig) (StringStore, error)
 }


### PR DESCRIPTION
We are now `golint`, `go vet` and `gosimple` clean.
I also fixed the starting of the prometheus server, simplified the http start/stop methods and implemented some things in the store start/stop methods.
The infohash middleware tests are nicer too.

This fixes #46 for the rewrite.