### PR TITLE
http: fixed bencoding, compact, added log

### DIFF
--- a/server/http/request.go
+++ b/server/http/request.go
@@ -34,7 +34,7 @@ func announceRequest(r *http.Request, cfg *httpConfig) (*chihaya.AnnounceRequest
 	}
 
 	compactStr, _ := q.String("compact")
-	request.Compact = compactStr != "0"
+	request.Compact = compactStr != "" && compactStr != "0"
 
 	infoHashes := q.InfoHashes()
 	if len(infoHashes) < 1 {

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -112,7 +112,10 @@ func (s *httpServer) serveAnnounce(w http.ResponseWriter, r *http.Request, p htt
 		return
 	}
 
-	writeAnnounceResponse(w, resp)
+	err = writeAnnounceResponse(w, resp)
+	if err != nil {
+		log.Println("error serializing response", err)
+	}
 }
 
 func (s *httpServer) serveScrape(w http.ResponseWriter, r *http.Request, p httprouter.Params) {

--- a/server/http/writer.go
+++ b/server/http/writer.go
@@ -91,7 +91,7 @@ func compact(peer chihaya.Peer) (buf []byte) {
 
 func dict(peer chihaya.Peer) bencode.Dict {
 	return bencode.Dict{
-		"peer id": peer.ID,
+		"peer id": string(peer.ID),
 		"ip":      peer.IP.String(),
 		"port":    peer.Port,
 	}


### PR DESCRIPTION
This fixes:

- an issue in bencoding the peer ID
- an issue in parsing the compact mode

Also adds:
- a log line in case writing a response to a client fails