### PR TITLE
API server

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -27,6 +27,7 @@ chihaya:
     - name: store
       config:
         addr: localhost:6880
+#        api_key: <your-api-key>
         request_timeout: 10s
         read_timeout: 10s
         write_timeout: 10s

--- a/server/store/README.md
+++ b/server/store/README.md
@@ -1,6 +1,7 @@
 ## The store Package
 
 The `store` package offers a storage interface and middlewares sufficient to run a public tracker based on it.
+Additionally, a modular API that exposes the store interface via HTTP is provided.
 
 ### Architecture
 
@@ -41,3 +42,253 @@ Most benchmarks come in two flavors: The "normal" version and the "1K" version.
 A normal benchmark uses the same value over and over again to benchmark one operation.
 A 1K benchmark uses a different value from a set of 1000 values for every iteration, this can show caching effects, if the driver uses them.
 The 1K benchmarks require a little more computation to select the values and thus typically yield slightly lower results even for a "perfect" cache, i.e. the memory implementation.
+
+### The API
+
+Every API response returns a JSON encoded `response`:
+
+```json
+{
+    "ok":false,
+    "error":"<nil>/<a string describing the error>",
+    "result":{}
+}
+```
+
+The `ok` field indicates whether the call was executed successfully.
+If `ok=false`, the `error` field will contain a string explaining the error that occurred during the execution.
+The `result` field is independent of the value `ok` has and contains a result of the call performed.
+
+The HTTP API is composed of two parts:
+- A set of predefined endpoints
+- Endpoints defined by middlewares
+
+#### Access restriction
+
+The easiest way to restrict access to the API is by setting the address to bind to localhost.
+If it is however desired to expose the API and still have access restriction, the store config allows to set the parameter `api_key`.
+If non-empty, the same key will be expected for every request made.
+It must be provided in at least one of these two ways:
+
+- The value of the `X-API-Key` HTTP header
+- A query parameter called `apikey`
+
+A mismatch will immediately fail the request and return a 403 status code.
+
+#### Types
+
+- `ContainedResult` is returned to indicate whether or not the requested resource is contained in the store:
+
+    ```json
+    {
+        "contained":false
+    }
+    ```
+
+- `CountResult` is returned when the number of elements in a collection is requested:
+
+    ```json
+    {
+        "count":1
+    }
+    ```
+
+- `PeersResult` contains two sets of `Peer`s: one for IPv4 and one for IPv6:
+
+    ```json
+    {
+        "peers4":[
+            {
+                "id":"00112233445566778899aabbccddeeff00112233",
+                "ip":"10.12.14.16",
+                "port":12345
+            }
+        ],
+        "peers6":[]
+    }
+    ```
+
+- `Peer` is a JSON encoding of a single peer:
+
+    ```json
+    {
+        "id":"00112233445566778899aabbccddeeff00112233",
+        "ip":"10.12.14.16",
+        "port":12345
+    }
+    ```
+
+    This type is used both as a result and as a parameter to some endpoints.  
+    All `Peer`s returned by the API have their ID encoded as a hexadecimal string.
+    `Peer`s that are used as a parameter can have their ID encoded as either a hexadecimal string, a base32 string or just a 20-byte JSON string.
+
+- `DualStackedPeer` is a type encapsulating two `Peer`s: one for IPv4 and one for IPv6:
+
+    ```json
+    {
+        "peer4":{
+            "id":"00112233445566778899aabbccddeeff00112233",
+            "ip":"10.12.14.16",
+            "port":12345
+        },
+        "peer6":{
+            "id":"112233445566778899aabbccddeeff0011223344",
+            "ip":"6464:aAbB:1234::6464",
+            "port":54321
+        }
+    }
+    ```
+
+    This type is used as a parameter.
+
+#### Predefined Endpoints
+
+- `PUT /ips/:ip` takes the given IPv4 or IPv6 address and adds it to the IP store.  
+    An example of this would be `PUT /ips/1.2.3.4`, which would add the IPv4 address `1.2.3.4` to the IP store.  
+    This method does not return a result.
+
+- `DELETE /ips/:ip` takes the given IPv4 or IPv6 address and attempts to delete it from the store.
+    If the IP address is not contained, an error and an HTTP code 404 will be returned.  
+    It is important to note that networks and single addresses are generally distinct and never interact with each other, except when matching against the IP store.
+    That means that, if the store contains a network `n`, which contains an IP address `a`, attempting to delete `a` will fail, because the IP store does not contain the single address `a`.  
+    An example of this would be `DELETE /ips/1.2.3.4`, which would attempt to delete the IPv4 address `1.2.3.4` from the string store.  
+    This method does not return a result.
+
+- `GET /ips/:ip` takes the given IPv4 or IPv6 address and matches it against the store.  
+    It is important to note that the address will be matched against both single-address entries and entire networks.  
+    This method returns a `ContainedResult`.
+
+- `PUT /networks/:network` takes the given network in CIDR notation and adds it to the IP store.  
+    An example of this would be `PUT /networks/1.2.3.4/24` which would add the network `1.2.3.0 - 1.2.3.255` to the IP store.  
+    This method does not return a result.
+
+- `DELETE /networks/:network` takes the given network in CIDR notation and attempts to delete it from the IP store.
+    If the network is not contained, an error and an HTTP code 404 will be returned.  
+    It is important to note, that this will _never_ remove single IP addresses from a larger network.
+    If you added the address `1.2.3.4` previously, deleting the network `1.2.3.4/24` will return an error.  
+    An example of this would be `DELETE /networks/1.2.3.4/24` which would attempt to delete the network `1.2.3.0 - 1.2.3.255` from the IP store.  
+    This method does not return a result.
+
+- `PUT /strings/:string` takes the provided string, URLEscapes it and stores it in the string store.  
+    It is important to note, that middlewares that depend on the string store often register API endpoints to make the interaction with the store easier.  
+    An example of this would be `PUT /strings/someString`, which would add `someString` to the string store.  
+    This method does not return a result.
+
+- `DELETE /strings/:string` takes the provided string, URLEscapes it and attempts to delete it from the string store.
+    If the string is not contained, an error and an HTTP code 404 will be returned.  
+    An example of this would be `DELETE /strings/someString`, which would attempt to delete `someString` from the string store.  
+    This method does not return a result.
+
+- `GET /strings/:string` takes the provided string, URLEscapes it and matches it against the store.  
+    This method returns a `ContainedResult`.
+
+- `GET /peers/seeders/:infohash` returns all seeders for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.  
+    This method returns a `PeersResult`.
+
+- `PUT /peers/seeders/:infohash` adds or replaces a given `Peer` as a seeder to the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.
+    The `Peer` is to be provided as a JSON object in the body of the request.  
+    This method does not return a result.
+
+- `DELETE /peers/seeders/:infohash` deletes a given `Peer` from the set of seeders of the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.
+    The `Peer` is to be provided as a JSON object in the body of the request.  
+    This method does not return a result.
+
+- `COUNT /peers/seeders/:infohash` or `GET /peers/numSeeders/:infohash` returns the number of seeders in the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.  
+    This method returns a `CountResult`.
+
+- `GET /peers/leechers/:infohash` returns all leechers for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.  
+    This method returns a `PeersResult`.
+
+- `PUT /peers/leechers/:infohash` adds or replaces a given `Peer` as a leecher to the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.
+    The `Peer` is to be provided as a JSON object in the body of the request.  
+    This method does not return a result.
+
+- `DELETE /peers/leechers/:infohash` deletes a given `Peer` from the set of leechers of the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.
+    The `Peer` is to be provided as a JSON object in the body of the request.  
+    This method does not return a result.
+
+- `COUNT /peers/leechers/:infohash` or `GET /peers/numLeechers/:infohash` returns the number of leechers in the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.  
+    This method returns a `CountResult`.
+
+- `POST /peers/graduateLeecher/:infohash` graduates a given `Peer` from a leecher to a seeder in the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.  
+    The `Peer` is to be provided as a JSON object in the body of the request.  
+    This method does not return a result.
+
+- `GET /peers/announce/:infohash?seeder=<true/false>` returns a set of peers from the swarm for the given infohash.  
+    The infohash can be provided as a hexadecimal string, a base32 string or URLEncoded.  
+    The `seeder` parameter describes whether the caller is a seeder or a leecher in the swarm.
+    This method takes a `DualStackedPeer` parameter, to be JSON encoded in the body of the request.  
+    This method returns a `PeersResult`.
+
+
+#### Endpoints Defined By Middlewares
+
+The store offers a set of methods to _register_ and _activate_ endpoints for the API.
+A package that offers a middleware that depends on the store should, if it's desired, register API methods to interact with the store in a way that is fitting to the middleware.
+In the middleware constructors of that package, these methods should be activated _once_.
+
+A boilerplate for the whole process would look like this:
+
+```go
+package middleware
+
+import (
+    "net/http"
+    
+    "github.com/chihaya/chihaya/server/store"
+    "github.com/chihaya/chihaya/tracker"
+)
+
+func init() {
+    tracker.RegisterAnnounceMiddleware("a", a)
+
+    store.RegisterNoResponseHandler(http.MethodPut, pathPutSomething, handlePutSomething)
+    store.RegisterHandler(http.MethodDelete, pathDeleteSomething, handleDeleteSomething)
+}
+
+const pathPutSomething = "/some/:thing"
+const pathDeleteSomething = "/some/:thing"
+
+var routesActivated sync.Once
+
+func activateRoutes() {
+    store.ActivateRoute(http.MethodPut, pathPutSomething)
+    store.ActivateRoute(http.MethodDelete, pathDeleteSomething)
+}
+
+func a(next tracker.AnnounceHandler) tracker.AnnounceHandler {
+    routesActivated.Do(activateRoutes)
+
+    return func(cfg *chihaya.TrackerConfig, req *chihaya.AnnounceRequest, resp *chihaya.AnnounceResponse) error {
+        // Do middleware stuff before the rest of the chain.
+        return next(cfg, req, resp)
+        // Do middleware stuff after the rest of the chain.
+    }
+}
+
+func handlePutSomething(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+    // handle API request
+    return http.StatusOK, nil
+}
+
+func handleDeleteSomething(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+    // handle API request and return a result or nil
+    return http.StatusOK, nil, nil
+}
+```
+
+This allows the API endpoints to be dependent on the config, which loads the middlewares, instead of package imports.
+
+All handler functions registered with the store will be wrapped in a recovery handler and a logging handler.
+It is idiomatic to panic in case of an internal error.
+The panic will be logged and an HTTP status 500, an appropriate error and no result will be returned to the caller.
+If on the other hand an error is returned, that error and the status code will be returned as-is to the caller.

--- a/server/store/middleware/client/README.md
+++ b/server/store/middleware/client/README.md
@@ -14,7 +14,16 @@ The `client_whitelist` middleware uses all clientIDs stored in the `StringStore`
 
 The clientID part of the peerID of an announce is matched against the `StringStore`, if it's _not_ contained within the `StringStore`, the announce is aborted.
 
-### Important things to notice
+## Routes
+
+Using any of the middlewares provided by this package will enable the following store API endpoints:
+
+- `PUT /clients/:client` will add the given clientID to the store.
+- `DELETE /clients/:client` will remove the given clientID from the store, if it was contained, or return an error otherwise.
+- `GET /clients/:client` will match the given clientID against the store.  
+    This method will return a `store.ContainedResult`.
+
+## Important things to notice
 
 Both middlewares operate on announce requests only.
 

--- a/server/store/middleware/client/routes.go
+++ b/server/store/middleware/client/routes.go
@@ -1,0 +1,88 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package client
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/chihaya/chihaya/server/store"
+)
+
+// PrefixClient is the prefix to be used for client IDs.
+const PrefixClient = "c-"
+
+const pathClient = "/clients/:client"
+
+var routesActivated sync.Once
+
+func activateRoutes() {
+	store.ActivateRoute(http.MethodPut, pathClient)
+	store.ActivateRoute(http.MethodDelete, pathClient)
+	store.ActivateRoute(http.MethodGet, pathClient)
+}
+
+func handleGetClient(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	client, err := getClient(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	match, err := store.MustGetStore().HasString(PrefixClient + client)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, store.ContainedResult{Contained: match}, nil
+}
+
+func handlePutClient(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	client, err := getClient(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = store.MustGetStore().PutString(PrefixClient + client)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func handleDeleteClient(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	client, err := getClient(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = store.MustGetStore().RemoveString(PrefixClient + client)
+	if err != nil {
+		if err == store.ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func getClient(p httprouter.Params) (string, error) {
+	clientString := p.ByName("client")
+	if clientString == "" {
+		return "", errors.New("misssing client")
+	}
+
+	clientString, err := url.QueryUnescape(clientString)
+	if err != nil || len(clientString) != 6 {
+		return "", errors.New("invalid client")
+	}
+
+	return clientString, nil
+}

--- a/server/store/middleware/client/whitelist.go
+++ b/server/store/middleware/client/whitelist.go
@@ -15,9 +15,6 @@ func init() {
 	tracker.RegisterAnnounceMiddleware("client_whitelist", whitelistAnnounceClient)
 }
 
-// PrefixClient is the prefix to be used for client peer IDs.
-const PrefixClient = "c-"
-
 // ErrNotWhitelistedClient is returned by an announce middleware if the
 // announcing Client is not whitelisted.
 var ErrNotWhitelistedClient = tracker.ClientError("client not whitelisted")
@@ -25,6 +22,8 @@ var ErrNotWhitelistedClient = tracker.ClientError("client not whitelisted")
 // whitelistAnnounceClient provides a middleware that only allows Clients to
 // announce that are stored in the StringStore.
 func whitelistAnnounceClient(next tracker.AnnounceHandler) tracker.AnnounceHandler {
+	routesActivated.Do(activateRoutes)
+
 	return func(cfg *chihaya.TrackerConfig, req *chihaya.AnnounceRequest, resp *chihaya.AnnounceResponse) error {
 		whitelisted, err := store.MustGetStore().HasString(PrefixClient + clientid.New(string(req.PeerID[:])))
 		if err != nil {

--- a/server/store/middleware/infohash/README.md
+++ b/server/store/middleware/infohash/README.md
@@ -39,7 +39,25 @@ The scrape middleware has two modes of operation: _Block_ and _Filter_.
 
 See the configuration section for information about how to configure the scrape middleware.
 
-### Important things to notice
+## Routes
+
+Using any of the middlewares provided by this package will enable the following two store API endpoints:
+
+- `PUT /infohashes/:infohash` will add the given infohash to the store.
+- `DELETE /infohashes/:infohash` will remove the given infohash from the store, if it was contained, or return an error otherwise.
+- `GET /infohashes/:infohash` will attempt to match the given infohash against the store.  
+    This method will return a combined result, consisting of a `store.ContainedResult` and an `infohashResult`.
+
+All API methods defined by this middleware will attempt to parse an infohash.
+As soon as they succeed, the result of the API call will contain an `infohashResult` of this form:
+
+```json
+{
+    "infohash":"00112233445566778899aabbccddeeff00112233"
+}
+```
+
+## Important things to notice
 
 Both blacklist and whitelist middleware use the same `StringStore`.
 It is therefore not advised to have both the `infohash_blacklist` and the `infohash_whitelist` announce or scrape middleware running.
@@ -50,7 +68,7 @@ If your store contains all addresses, no announces/scrapes will be blocked by th
 Also note that the announce and scrape middleware both use the same `StringStore`.
 It is therefore not possible to use different infohashes for black-/whitelisting on announces and scrape requests.
 
-### Configuration
+## Configuration
 
 The scrape middleware is configurable.
 

--- a/server/store/middleware/infohash/routes.go
+++ b/server/store/middleware/infohash/routes.go
@@ -1,0 +1,139 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package infohash
+
+import (
+	"encoding/base32"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/chihaya/chihaya"
+	"github.com/chihaya/chihaya/server/store"
+)
+
+// PrefixInfohash is the prefix to be used for infohashes.
+const PrefixInfohash = "ih-"
+
+const pathInfohash = "/infohashes/*infohash"
+
+type infohashResult struct {
+	InfoHash string `json:"infohash"`
+}
+
+type infohashContainedResult struct {
+	infohashResult
+	store.ContainedResult
+}
+
+var routesActivated sync.Once
+
+func activateRoutes() {
+	store.ActivateRoute(http.MethodPut, pathInfohash)
+	store.ActivateRoute(http.MethodDelete, pathInfohash)
+	store.ActivateRoute(http.MethodGet, pathInfohash)
+}
+
+func handleGetInfohash(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	infohash, err := getInfohash(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+	result := infohashContainedResult{
+		infohashResult: infohashResult{
+			InfoHash: hex.EncodeToString([]byte(infohash[:])),
+		},
+	}
+
+	match, err := store.MustGetStore().HasString(PrefixInfohash + string(infohash[:]))
+	if err != nil {
+		panic(err)
+	}
+	result.Contained = match
+
+	return http.StatusOK, result, nil
+}
+
+func handlePutInfohash(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	infohash, err := getInfohash(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+	result := infohashResult{
+		InfoHash: hex.EncodeToString([]byte(infohash[:])),
+	}
+
+	err = store.MustGetStore().PutString(PrefixInfohash + string(infohash[:]))
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, result, nil
+}
+
+func handleDeleteInfohash(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	infohash, err := getInfohash(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+	result := infohashResult{
+		InfoHash: hex.EncodeToString([]byte(infohash[:])),
+	}
+
+	err = store.MustGetStore().RemoveString(PrefixInfohash + string(infohash[:]))
+	if err != nil {
+		if err == store.ErrResourceDoesNotExist {
+			return http.StatusNotFound, result, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, result, nil
+}
+
+func getInfohash(p httprouter.Params) (chihaya.InfoHash, error) {
+	infohashString := p.ByName("infohash")
+	if infohashString == "" {
+		return chihaya.InfoHash{}, errors.New("missing infohash")
+	}
+
+	infohashString = infohashString[1:]
+
+	var (
+		parsedBytes    []byte
+		parsedInfohash string
+		err            error
+	)
+
+	switch len(infohashString) {
+	case 40:
+		parsedBytes, err = hex.DecodeString(infohashString)
+		if err != nil || len(parsedBytes) != 20 {
+			break
+		}
+		parsedInfohash = string(parsedBytes)
+	case 32:
+		parsedBytes, err = base32.StdEncoding.DecodeString(infohashString)
+		if err != nil || len(parsedBytes) != 20 {
+			break
+		}
+		parsedInfohash = string(parsedBytes)
+	default:
+	}
+
+	if err != nil || len(parsedInfohash) != 20 {
+		// always try URLEncoding, no matter the length.
+		parsedInfohash, err = url.QueryUnescape(infohashString)
+		if err != nil || len(parsedInfohash) != 20 {
+			return chihaya.InfoHash{}, errors.New("invalid infohash")
+		}
+	}
+
+	return chihaya.InfoHashFromString(parsedInfohash), nil
+}

--- a/server/store/middleware/infohash/whitelist.go
+++ b/server/store/middleware/infohash/whitelist.go
@@ -14,12 +14,11 @@ func init() {
 	tracker.RegisterScrapeMiddlewareConstructor("infohash_whitelist", whitelistScrapeInfohash)
 }
 
-// PrefixInfohash is the prefix to be used for infohashes.
-const PrefixInfohash = "ih-"
-
 // whitelistAnnounceInfohash provides a middleware that only allows announces
 // for infohashes that are not stored in a StringStore
 func whitelistAnnounceInfohash(next tracker.AnnounceHandler) tracker.AnnounceHandler {
+	routesActivated.Do(activateRoutes)
+
 	return func(cfg *chihaya.TrackerConfig, req *chihaya.AnnounceRequest, resp *chihaya.AnnounceResponse) (err error) {
 		whitelisted, err := mustGetStore().HasString(PrefixInfohash + string(req.InfoHash[:]))
 
@@ -43,6 +42,8 @@ func whitelistAnnounceInfohash(next tracker.AnnounceHandler) tracker.AnnounceHan
 //
 // ErrUnknownMode is returned if the Mode specified in the config is unknown.
 func whitelistScrapeInfohash(c chihaya.MiddlewareConfig) (tracker.ScrapeMiddleware, error) {
+	routesActivated.Do(activateRoutes)
+
 	cfg, err := newConfig(c)
 	if err != nil {
 		return nil, err

--- a/server/store/peer_store.go
+++ b/server/store/peer_store.go
@@ -43,14 +43,15 @@ type PeerStore interface {
 	// announce.
 	//
 	// If seeder is true then the peers returned will only be leechers, the
-	// ammount of leechers returned will be the smaller value of numWant or
+	// amount of leechers returned will be the smaller value of numWant or
 	// the available leechers.
 	// If it is false then seeders will be returned up until numWant or the
 	// available seeders, whichever is smaller. If the available seeders is
-	// less than numWant then peers are returned until numWant or they run out.
+	// less than numWant then leechers are returned until numWant or they
+	// run out.
 	AnnouncePeers(infoHash chihaya.InfoHash, seeder bool, numWant int, peer4, peer6 chihaya.Peer) (peers, peers6 []chihaya.Peer, err error)
-	// CollectGarbage deletes peers from the peerStore which are older than the
-	// cutoff time.
+	// CollectGarbage deletes peers from the peerStore which are older than
+	// the cutoff time.
 	CollectGarbage(cutoff time.Time) error
 
 	// GetSeeders gets all the seeders for a particular infoHash.

--- a/server/store/routes.go
+++ b/server/store/routes.go
@@ -1,0 +1,622 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package store
+
+import (
+	"encoding/base32"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/chihaya/chihaya"
+	"github.com/julienschmidt/httprouter"
+)
+
+// ResponseFunc is the type of function that handles an API request and returns
+// an HTTP status code, an optional response to be embedded and an error.
+type ResponseFunc func(http.ResponseWriter, *http.Request, httprouter.Params) (status int, result interface{}, err error)
+
+// NoResultResponseFunc is the type of function that handles an API request and
+// returns an HTTP status code and an error.
+type NoResultResponseFunc func(http.ResponseWriter, *http.Request, httprouter.Params) (status int, err error)
+
+// ErrInternalServerError is the error used for recovered API calls.
+var ErrInternalServerError = errors.New("internal server error")
+
+type response struct {
+	Ok     bool        `json:"ok"`
+	Error  string      `json:"error,omitempty"`
+	Result interface{} `json:"result,omitempty"`
+}
+
+// ContainedResult is the result returned by endpoints that check if a given
+// entity is contained in the store.
+type ContainedResult struct {
+	Contained bool `json:"contained"`
+}
+
+type countResult struct {
+	Count int `json:"count"`
+}
+
+type peersResult struct {
+	Peers4 []peer `json:"peers4"`
+	Peers6 []peer `json:"peers6"`
+}
+
+type peer struct {
+	ID   string `json:"id"`
+	IP   string `json:"ip"`
+	Port uint16 `json:"port"`
+}
+
+type dualStackedPeer struct {
+	Peer4 peer `json:"peer4"`
+	Peer6 peer `json:"peer6"`
+}
+
+func (s *Store) makeHandler(inner ResponseFunc) httprouter.Handle {
+	if s.cfg.APIKey != "" {
+		inner = authorizationHandler(inner, s.cfg.APIKey)
+	}
+
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		resp := response{}
+		handler := logHandler(recoverHandler(inner))
+
+		status, result, err := handler(w, r, p)
+		if err != nil {
+			resp.Error = err.Error()
+		} else {
+			resp.Ok = true
+		}
+		if result != nil {
+			resp.Result = result
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		w.WriteHeader(status)
+
+		err = json.NewEncoder(w).Encode(resp)
+		if err != nil {
+			log.Println("API: unable to send response:", err)
+		}
+	}
+}
+
+func authorizationHandler(inner ResponseFunc, apiKey string) ResponseFunc {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+		token := getAPIKey(r)
+		if token != apiKey {
+			return http.StatusForbidden, nil, errors.New("invalid API key")
+		}
+
+		return inner(w, r, p)
+	}
+}
+
+func getAPIKey(r *http.Request) string {
+	token := r.Header.Get("X-API-Key")
+
+	if token == "" {
+		token = r.URL.Query().Get("apikey")
+	}
+
+	return token
+}
+
+func logHandler(inner ResponseFunc) ResponseFunc {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+		before := time.Now()
+
+		status, result, err := inner(w, r, p)
+		delta := time.Since(before)
+
+		log.Printf("%d %s %s %s %s", status, delta.String(), r.RemoteAddr, r.Method, r.URL.EscapedPath())
+
+		return status, result, err
+	}
+}
+
+func recoverHandler(inner ResponseFunc) ResponseFunc {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (status int, result interface{}, err error) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Println("API: recovered:", rec)
+				status = http.StatusInternalServerError
+				result = nil
+				err = ErrInternalServerError
+			}
+		}()
+
+		status, result, err = inner(w, r, p)
+		return
+	}
+}
+
+func noResultHandler(inner NoResultResponseFunc) ResponseFunc {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+		status, err := inner(w, r, p)
+
+		return status, nil, err
+	}
+}
+
+func (s *Store) handleGetIP(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	ip, err := getIP(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	match, err := s.HasIP(ip)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, ContainedResult{Contained: match}, nil
+}
+
+func (s *Store) handlePutIP(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	ip, err := getIP(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.AddIP(ip)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *Store) handleDeleteIP(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	ip, err := getIP(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.RemoveIP(ip)
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func getIP(p httprouter.Params) (net.IP, error) {
+	ipString := p.ByName("ip")
+	if ipString == "" {
+		return nil, errors.New("missing IP")
+	}
+
+	ip := net.ParseIP(ipString)
+	if ip == nil {
+		return nil, errors.New("invalid IP")
+	}
+
+	return ip, nil
+}
+
+func (s *Store) handlePutNetwork(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	network, err := getNetwork(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.AddNetwork(network)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *Store) handleDeleteNetwork(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	network, err := getNetwork(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.RemoveNetwork(network)
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func getNetwork(p httprouter.Params) (string, error) {
+	networkString := p.ByName("network")
+	if len(networkString) < 2 {
+		return "", errors.New("missing network")
+	}
+
+	// Remove preceding slash.
+	networkString = networkString[1:]
+
+	_, _, err := net.ParseCIDR(networkString)
+	if err != nil {
+		return "", errors.New("invalid network")
+	}
+
+	return networkString, nil
+}
+
+func (s *Store) handleGetString(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	str, err := getString(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	match, err := s.HasString(str)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, ContainedResult{Contained: match}, nil
+}
+
+func (s *Store) handlePutString(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	str, err := getString(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.PutString(str)
+	if err != nil {
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *Store) handleDeleteString(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	str, err := getString(p)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.RemoveString(str)
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func getString(p httprouter.Params) (string, error) {
+	str := p.ByName("string")
+	if str == "" {
+		return "", errors.New("missing string")
+	}
+
+	str = str[1:]
+	parsed, err := url.QueryUnescape(str)
+	if err != nil {
+		return "", errors.New("invalid string")
+	}
+
+	return parsed, nil
+}
+
+func (s *Store) handleGetSeeders(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	return s.handleGetPeers(w, r, p, true)
+}
+
+func (s *Store) handleGetLeechers(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	return s.handleGetPeers(w, r, p, false)
+}
+
+func (s *Store) handleGetPeers(w http.ResponseWriter, r *http.Request, p httprouter.Params, seeders bool) (int, interface{}, error) {
+	ih, err := getInfohash(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	var peers4, peers6 []chihaya.Peer
+	if seeders {
+		peers4, peers6, err = s.GetSeeders(ih)
+	} else {
+		peers4, peers6, err = s.GetLeechers(ih)
+	}
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, nil, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, toPeersResult(peers4, peers6), nil
+}
+
+func (s *Store) handlePutSeeder(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	return s.handlePutPeer(w, r, p, true)
+}
+
+func (s *Store) handlePutLeecher(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	return s.handlePutPeer(w, r, p, false)
+}
+
+func (s *Store) handlePutPeer(w http.ResponseWriter, r *http.Request, params httprouter.Params, seeder bool) (int, error) {
+	ih, err := getInfohash(params)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	rawPeer := peer{}
+	err = json.NewDecoder(r.Body).Decode(&rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, errors.New("invalid peer")
+	}
+
+	p, err := decodePeer(rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	if seeder {
+		err = s.PutSeeder(ih, p)
+	} else {
+		err = s.PutLeecher(ih, p)
+	}
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *Store) handleDeleteSeeder(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	return s.handleDeletePeer(w, r, p, true)
+}
+
+func (s *Store) handleDeleteLeecher(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, error) {
+	return s.handleDeletePeer(w, r, p, false)
+}
+
+func (s *Store) handleDeletePeer(w http.ResponseWriter, r *http.Request, params httprouter.Params, seeder bool) (int, error) {
+	ih, err := getInfohash(params)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	rawPeer := peer{}
+	err = json.NewDecoder(r.Body).Decode(&rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, errors.New("invalid peer")
+	}
+
+	p, err := decodePeer(rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	if seeder {
+		err = s.DeleteSeeder(ih, p)
+	} else {
+		err = s.DeleteLeecher(ih, p)
+	}
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *Store) handleNumSeeders(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	return s.handleNumPeers(w, r, p, true)
+}
+
+func (s *Store) handleNumLeechers(w http.ResponseWriter, r *http.Request, p httprouter.Params) (int, interface{}, error) {
+	return s.handleNumPeers(w, r, p, false)
+}
+
+func (s *Store) handleNumPeers(w http.ResponseWriter, r *http.Request, p httprouter.Params, seeders bool) (int, interface{}, error) {
+	ih, err := getInfohash(p)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	var count int
+	if seeders {
+		count = s.NumSeeders(ih)
+	} else {
+		count = s.NumLeechers(ih)
+	}
+
+	return http.StatusOK, countResult{Count: count}, nil
+}
+
+func (s *Store) handleGraduateLeecher(w http.ResponseWriter, r *http.Request, params httprouter.Params) (int, error) {
+	ih, err := getInfohash(params)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	rawPeer := peer{}
+	err = json.NewDecoder(r.Body).Decode(&rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, errors.New("invalid peer")
+	}
+
+	p, err := decodePeer(rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	err = s.GraduateLeecher(ih, p)
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (s *Store) handleAnnounce(w http.ResponseWriter, r *http.Request, params httprouter.Params) (int, interface{}, error) {
+	ih, err := getInfohash(params)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	isSeeder := params.ByName("seeder")
+	seeder, err := strconv.ParseBool(isSeeder)
+	if err != nil {
+		return http.StatusBadRequest, nil, errors.New("invalid value for seeder")
+	}
+
+	rawPeer := dualStackedPeer{}
+	err = json.NewDecoder(r.Body).Decode(&rawPeer)
+	if err != nil {
+		return http.StatusBadRequest, nil, errors.New("invalid peer")
+	}
+
+	var p4, p6 chihaya.Peer
+
+	if rawPeer.Peer4.IP != "" {
+		p4, err = decodePeer(rawPeer.Peer4)
+		if err != nil {
+			return http.StatusBadRequest, nil, err
+		}
+	}
+
+	if rawPeer.Peer6.IP != "" {
+		p6, err = decodePeer(rawPeer.Peer6)
+		if err != nil {
+			return http.StatusBadRequest, nil, err
+		}
+	}
+
+	peers4, peers6, err := s.AnnouncePeers(ih, seeder, 50, p4, p6)
+	if err != nil {
+		if err == ErrResourceDoesNotExist {
+			return http.StatusNotFound, nil, err
+		}
+		panic(err)
+	}
+
+	return http.StatusOK, toPeersResult(peers4, peers6), nil
+}
+
+func toPeersResult(peers4, peers6 []chihaya.Peer) peersResult {
+	toReturn := peersResult{
+		Peers4: make([]peer, len(peers4)),
+		Peers6: make([]peer, len(peers6)),
+	}
+
+	for i, p := range peers4 {
+		toReturn.Peers4[i] = encodePeer(p)
+	}
+
+	for i, p := range peers6 {
+		toReturn.Peers6[i] = encodePeer(p)
+	}
+
+	return toReturn
+}
+
+func encodePeer(p chihaya.Peer) peer {
+	return peer{
+		ID:   hex.EncodeToString([]byte(p.ID[:])),
+		IP:   p.IP.String(),
+		Port: p.Port,
+	}
+}
+
+func decodePeer(p peer) (chihaya.Peer, error) {
+	var parsedPeerID []byte
+	var err error
+
+	switch len(p.ID) {
+	case 40:
+		parsedPeerID, err = hex.DecodeString(p.ID)
+	case 32:
+		parsedPeerID, err = base32.StdEncoding.DecodeString(p.ID)
+	case 20:
+		parsedPeerID = []byte(p.ID)
+	default:
+		return chihaya.Peer{}, errors.New("invalid peer ID")
+	}
+	if err != nil || len(parsedPeerID) != 20 {
+		return chihaya.Peer{}, errors.New("invalid peer ID")
+	}
+
+	ip := net.ParseIP(p.IP)
+	if ip == nil {
+		return chihaya.Peer{}, errors.New("invalid IP")
+	}
+
+	return chihaya.Peer{
+		ID:   chihaya.PeerIDFromBytes(parsedPeerID),
+		IP:   ip,
+		Port: p.Port,
+	}, nil
+}
+
+func getInfohash(p httprouter.Params) (chihaya.InfoHash, error) {
+	infohashString := p.ByName("infohash")
+	if infohashString == "" {
+		return chihaya.InfoHash{}, errors.New("missing infohash")
+	}
+
+	infohashString = infohashString[1:]
+
+	var (
+		parsedBytes    []byte
+		parsedInfohash string
+		err            error
+	)
+
+	switch len(infohashString) {
+	case 40:
+		parsedBytes, err = hex.DecodeString(infohashString)
+		if err != nil || len(parsedBytes) != 20 {
+			break
+		}
+		parsedInfohash = string(parsedBytes)
+	case 32:
+		parsedBytes, err = base32.StdEncoding.DecodeString(infohashString)
+		if err != nil || len(parsedBytes) != 20 {
+			break
+		}
+		parsedInfohash = string(parsedBytes)
+	default:
+	}
+
+	if err != nil || len(parsedInfohash) != 20 {
+		// always try URLEncoding, no matter the length.
+		parsedInfohash, err = url.QueryUnescape(infohashString)
+		if err != nil || len(parsedInfohash) != 20 {
+			return chihaya.InfoHash{}, errors.New("invalid infohash")
+		}
+	}
+
+	return chihaya.InfoHashFromString(parsedInfohash), nil
+}

--- a/server/store/server.go
+++ b/server/store/server.go
@@ -1,0 +1,194 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package store
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/tylerb/graceful"
+)
+
+// ErrInvalidMethod is returned for attempts to register or activate an endpoint
+// with an invalid HTTP method.
+var ErrInvalidMethod = errors.New("invalid method")
+
+// ErrInvalidHandler is returned for attempts to register a nil handler.
+var ErrInvalidHandler = errors.New("invalid handler")
+
+// ErrRouteNotRegistered is returned for attempts to activate a route without a
+// previously registered handler.
+var ErrRouteNotRegistered = errors.New("route not registered")
+
+var registeredRoutes map[string]map[string]ResponseFunc
+var activatedRoutes map[string]map[string]ResponseFunc
+
+// RegisterHandler registers the given ResponseFunc at the given path and
+// HTTP method.
+//
+// Calling this function twice with the same method and path will overwrite
+// the ResponseFunc registered earlier.
+// Calling this function with a nil ResponseFunc will return ErrInvalidHandler.
+// Calling this function with an invalid method returns ErrInvalidMethod.
+func RegisterHandler(method, path string, handler ResponseFunc) error {
+	if handler == nil {
+		return ErrInvalidHandler
+	}
+
+	m := strings.ToUpper(method)
+	if m != http.MethodGet && m != http.MethodPut && m != http.MethodDelete {
+		return ErrInvalidMethod
+	}
+
+	if registeredRoutes[m] == nil {
+		registeredRoutes[m] = make(map[string]ResponseFunc)
+	}
+
+	registeredRoutes[m][path] = handler
+
+	log.Printf("Store API: Registered: %s %s", method, path)
+
+	return nil
+}
+
+// RegisterNoResponseHandler registers the given NoResponseHandler at the given
+// path and HTTP method.
+//
+// Internally, this function encapsulates the given NoResultResponseFunc in a
+// ResponseFunc and calls RegisterHandler.
+//
+// Calling this function twice with the same method and path will overwrite
+// the ResponseFunc registered earlier.
+// Calling this function with a nil NoResultResponseFunc will return
+// ErrInvalidHandler.
+// Calling this function with an invalid method returns ErrInvalidMethod.
+func RegisterNoResponseHandler(method, path string, handler NoResultResponseFunc) error {
+	if handler == nil {
+		return ErrInvalidHandler
+	}
+
+	return RegisterHandler(method, path, noResultHandler(handler))
+}
+
+// ActivateRoute marks the given method/path combination active and enables the
+// handler previously registered for that endpoint.
+//
+// This function should be called by a MiddlewareConstructor once while the
+// tracker boots.
+//
+// Calling this function with an invalid method returns ErrInvalidMethod.
+// Calling this function for an endpoint without a previously registered handler
+// will return ErrRouteNotRegistered.
+// Activating the exact same route twice will panic.
+// Activating a route with the same behaviour but different representations
+// will panic in routes().
+func ActivateRoute(method, path string) error {
+	m := strings.ToUpper(method)
+	if m != http.MethodGet && m != http.MethodPut && m != http.MethodDelete {
+		return ErrInvalidMethod
+	}
+
+	if registeredRoutes[m] == nil || registeredRoutes[m][path] == nil {
+		return ErrRouteNotRegistered
+	}
+
+	if activatedRoutes[m] == nil {
+		activatedRoutes[m] = make(map[string]ResponseFunc)
+	}
+
+	if activatedRoutes[m][path] != nil {
+		panic(fmt.Sprintf("route %s %s activated more than once", m, path))
+	}
+
+	activatedRoutes[m][path] = registeredRoutes[m][path]
+
+	log.Printf("Store API: Activated: %s %s", method, path)
+
+	return nil
+}
+
+func (s *Store) routes() http.Handler {
+	r := httprouter.New()
+	r.GET("/ips/:ip", s.makeHandler(s.handleGetIP))
+	r.PUT("/ips/:ip", s.makeHandler(noResultHandler(s.handlePutIP)))
+	r.DELETE("/ips/:ip", s.makeHandler(noResultHandler(s.handleDeleteIP)))
+
+	r.PUT("/networks/*network", s.makeHandler(noResultHandler(s.handlePutNetwork)))
+	r.DELETE("/networks/*network", s.makeHandler(noResultHandler(s.handleDeleteNetwork)))
+
+	r.GET("/strings/*string", s.makeHandler(s.handleGetString))
+	r.PUT("/strings/*string", s.makeHandler(noResultHandler(s.handlePutString)))
+	r.DELETE("/strings/*string", s.makeHandler(noResultHandler(s.handleDeleteString)))
+
+	r.GET("/peers/seeders/*infohash", s.makeHandler(s.handleGetSeeders))
+	r.PUT("/peers/seeders/*infohash", s.makeHandler(noResultHandler(s.handlePutSeeder)))
+	r.DELETE("/peers/seeders/*infohash", s.makeHandler(noResultHandler(s.handleDeleteSeeder)))
+	r.Handle("COUNT", "/peers/seeders/*infohash", s.makeHandler(s.handleNumSeeders))
+	r.GET("/peers/numSeeders/*infohash", s.makeHandler(s.handleNumSeeders))
+
+	r.GET("/peers/leechers/*infohash", s.makeHandler(s.handleGetLeechers))
+	r.PUT("/peers/leechers/*infohash", s.makeHandler(noResultHandler(s.handlePutLeecher)))
+	r.DELETE("/peers/leechers/*infohash", s.makeHandler(noResultHandler(s.handleDeleteLeecher)))
+	r.Handle("COUNT", "/peers/leechers/*infohash", s.makeHandler(s.handleNumLeechers))
+	r.GET("/peers/numLeechers/*infohash", s.makeHandler(s.handleNumLeechers))
+
+	r.POST("/peers/graduateLeecher/*infohash", s.makeHandler(noResultHandler(s.handleGraduateLeecher)))
+
+	r.GET("/peers/announce/*infohash", s.makeHandler(s.handleAnnounce))
+
+	for m, paths := range activatedRoutes {
+		for path, handle := range paths {
+			r.Handle(m, path, s.makeHandler(handle))
+		}
+	}
+
+	return r
+}
+
+// Start starts the store drivers and blocks until all of them exit.
+func (s *Store) Start() {
+	s.grace = &graceful.Server{
+		Server: &http.Server{
+			Addr:         s.cfg.Addr,
+			Handler:      s.routes(),
+			ReadTimeout:  s.cfg.ReadTimeout,
+			WriteTimeout: s.cfg.WriteTimeout,
+		},
+		Timeout:          s.cfg.RequestTimeout,
+		NoSignalHandling: true,
+	}
+
+	if err := s.grace.ListenAndServe(); err != nil {
+		if opErr, ok := err.(*net.OpError); !ok || (ok && opErr.Op != "accept") {
+			log.Printf("Failed to gracefully run store server: %s", err.Error())
+			panic(err)
+		}
+	}
+
+	<-s.shutdown
+}
+
+// Stop stops the store drivers and waits for them to exit.
+func (s *Store) Stop() {
+	s.grace.Stop(s.grace.Timeout)
+	<-s.grace.StopChan()
+
+	errors := s.sg.Stop()
+	if len(errors) == 0 {
+		log.Println("Store server shut down cleanly")
+	} else {
+		log.Println("Store server: failed to shutdown drivers")
+		for _, err := range errors {
+			log.Println(err.Error())
+		}
+	}
+
+	close(s.shutdown)
+}


### PR DESCRIPTION
API Server now for master.

Implemented endpoints:
- `(GET|PUT|DELETE) /ips/:ip`
- `(PUT|DELETE) /networks/:network`
- `(GET|PUT|DELETE) /strings/:string`
- `(GET|PUT|DELETE|COUNT) /peers/seeders/:infohash`
- `(GET|PUT|DELETE|COUNT) /peers/leechers/:infohash`
- `GET /peers/num(Leechers|Seeders)/:infohash`
- `GET /peers/announce/:infohash`
- `POST /peers/graduateLeecher/:infohash`
- `(GET|PUT|DELETE) /clients/:client` if client middleware is used
- `(GET|PUT|DELETE) /infohashes/:infohash` if infohash middleware is used

Other changes:
- Middleware can register/activate endpoints with the store
- Some log lines here and there

Needs clarification maybe:
- #177 describes questions about the peer store interface, especially regarding ErrDoesNotExist - this affects the API server (kinda)