### PR TITLE
travis: add golint, goimports and go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ go:
 sudo: false
 install:
 - go get -t ./...
+- go get -u github.com/golang/lint/golint
+- go get -u golang.org/x/tools/cmd/goimports
 script:
 - go test -v $(go list ./... | grep -v /vendor/)
+- go vet $(go list ./... | grep -v /vendor/)
+- diff <(goimports -d $(find . -type f -name '*.go' -not -path "./vendor/*")) <(printf "")
+- for d in $(go list ./... | grep -v /vendor/); do diff <(golint $d) <(printf ""); done
 notifications:
   irc:
     channels:


### PR DESCRIPTION
This adds goimports, go vet and golint to travis. It excludes the `/vendor/` directory, just in case we use that at some point.

Good build example:
https://travis-ci.org/mrd0ll4r/chihaya/jobs/131722168

Bad build examples:
https://travis-ci.org/mrd0ll4r/chihaya/jobs/131721602
https://travis-ci.org/mrd0ll4r/chihaya/jobs/131720725

Example with an unclean file in the `/vendor/` directory:
https://travis-ci.org/mrd0ll4r/chihaya/jobs/131720094