### PR TITLE
bolt: add string store

### DIFF
--- a/server/store/bolt/README.md
+++ b/server/store/bolt/README.md
@@ -1,0 +1,21 @@
+## `bolt` Store Implementations
+
+This package provides implementations of the `store` APIs using [bolt].
+They register with the store under the name `bolt`.
+Currently only the `StringStore` is implemented.
+
+[bolt]: https://github.com/boltdb/bolt
+
+### Configuration
+
+Bolt uses a single database file on disk, it is therefore necessary to specify which file a driver should use.
+Note that every driver opens a new `bolt.DB`, which means that they cannot share the same file.
+
+A typical configuration for the `StringStore` would look like this:
+
+```yaml
+string_store:
+  name: bolt
+  config:
+    file: strings.db
+```

--- a/server/store/bolt/config.go
+++ b/server/store/bolt/config.go
@@ -1,0 +1,46 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package bolt
+
+import (
+	"errors"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/chihaya/chihaya/server/store"
+)
+
+// ErrMissingFile is returned if no database file was specified.
+var ErrMissingFile = errors.New("database file must not be empty")
+
+// ErrMissingConfig is returned if a non-existent config is opened.
+var ErrMissingConfig = errors.New("missing config")
+
+type boltConfig struct {
+	File string `yaml:"file"`
+}
+
+func newBoltConfig(storecfg *store.DriverConfig) (*boltConfig, error) {
+	if storecfg == nil || storecfg.Config == nil {
+		return nil, ErrMissingConfig
+	}
+
+	bytes, err := yaml.Marshal(storecfg.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg boltConfig
+	err = yaml.Unmarshal(bytes, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.File == "" {
+		return nil, ErrMissingFile
+	}
+
+	return &cfg, nil
+}

--- a/server/store/bolt/config_test.go
+++ b/server/store/bolt/config_test.go
@@ -1,0 +1,36 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package bolt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/chihaya/chihaya/server/store"
+)
+
+func TestNewBoltConfig(t *testing.T) {
+	cfg, err := newBoltConfig(&store.DriverConfig{Config: boltConfig{File: "a"}})
+	require.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	cfg, err = newBoltConfig(nil)
+	require.Equal(t, ErrMissingConfig, err)
+	require.Nil(t, cfg)
+
+	cfg, err = newBoltConfig(&store.DriverConfig{})
+	require.Equal(t, ErrMissingConfig, err)
+	require.Nil(t, cfg)
+
+	cfg, err = newBoltConfig(&store.DriverConfig{Config: nil})
+	require.Equal(t, ErrMissingConfig, err)
+	require.Nil(t, cfg)
+
+	cfg, err = newBoltConfig(&store.DriverConfig{Config: boltConfig{}})
+	require.Equal(t, ErrMissingFile, err)
+	require.Nil(t, cfg)
+
+}

--- a/server/store/bolt/string_store.go
+++ b/server/store/bolt/string_store.go
@@ -1,0 +1,111 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package bolt
+
+import (
+	"errors"
+	"time"
+
+	"github.com/boltdb/bolt"
+
+	"github.com/chihaya/chihaya/server/store"
+)
+
+func init() {
+	store.RegisterStringStoreDriver("bolt", &stringStoreDriver{})
+}
+
+// ErrMissingBucket is returned if a required bucket does not exist.
+var ErrMissingBucket = errors.New("missing bucket")
+
+const val = ""
+const stringsBucketKey = "strings"
+
+type stringStoreDriver struct{}
+
+func (d *stringStoreDriver) New(storecfg *store.DriverConfig) (store.StringStore, error) {
+	cfg, err := newBoltConfig(storecfg)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := bolt.Open(cfg.File, 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err = tx.CreateBucketIfNotExists([]byte(stringsBucketKey))
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &stringStore{
+		db: db,
+	}, nil
+}
+
+type stringStore struct {
+	db *bolt.DB
+}
+
+func (s *stringStore) PutString(str string) error {
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(stringsBucketKey))
+		if b == nil {
+			return ErrMissingBucket
+		}
+
+		return b.Put([]byte(str), []byte(val))
+	})
+
+	return err
+}
+
+func (s *stringStore) HasString(str string) (contained bool, err error) {
+	err = s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(stringsBucketKey))
+		if b == nil {
+			return ErrMissingBucket
+		}
+
+		contained = b.Get([]byte(str)) != nil
+
+		return nil
+	})
+
+	return
+}
+
+func (s *stringStore) RemoveString(str string) error {
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(stringsBucketKey))
+		if b == nil {
+			return ErrMissingBucket
+		}
+
+		if b.Get([]byte(str)) == nil {
+			return store.ErrResourceDoesNotExist
+		}
+
+		return b.Delete([]byte(str))
+	})
+
+	return err
+}
+
+func (s *stringStore) Stop() <-chan error {
+	toReturn := make(chan error)
+	go func() {
+		err := s.db.Close()
+		if err != nil {
+			toReturn <- err
+		}
+		close(toReturn)
+	}()
+	return toReturn
+}

--- a/server/store/bolt/string_store_test.go
+++ b/server/store/bolt/string_store_test.go
@@ -1,0 +1,133 @@
+// Copyright 2016 The Chihaya Authors. All rights reserved.
+// Use of this source code is governed by the BSD 2-Clause license,
+// which can be found in the LICENSE file.
+
+package bolt
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/chihaya/chihaya/server/store"
+)
+
+var (
+	driver                 = &stringStoreDriver{}
+	stringStoreTester      = store.PrepareStringStoreTester(driver)
+	stringStoreBenchmarker = store.PrepareStringStoreBenchmarker(driver)
+)
+
+const benchDB = "bench.db"
+
+func TestStringStoreDriver_New(t *testing.T) {
+	ss, err := driver.New(nil)
+	require.Equal(t, ErrMissingConfig, err)
+	require.Nil(t, ss)
+
+	f, err := os.Create("test.db")
+	require.Nil(t, err)
+	require.NotNil(t, f)
+	defer os.Remove("test.db")
+	defer f.Close()
+
+	fmt.Fprint(f, "garbage")
+
+	ss, err = driver.New(&store.DriverConfig{Config: boltConfig{File: "test.db"}})
+	require.NotNil(t, err)
+	require.Nil(t, ss)
+}
+
+func TestStringStore(t *testing.T) {
+	defer os.Remove("test.db")
+	stringStoreTester.TestStringStore(t, &store.DriverConfig{Config: boltConfig{File: "test.db"}})
+}
+
+type benchmarkFunc func(*testing.B, *store.DriverConfig)
+
+func benchmarkHarness(f benchmarkFunc, b *testing.B) {
+	defer os.Remove(benchDB)
+	f(b, &store.DriverConfig{Config: boltConfig{File: benchDB}})
+}
+
+func BenchmarkStringStore_AddShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.AddShort, b)
+}
+
+func BenchmarkStringStore_AddLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.AddLong, b)
+}
+
+func BenchmarkStringStore_LookupShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.LookupShort, b)
+}
+
+func BenchmarkStringStore_LookupLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.LookupLong, b)
+}
+
+func BenchmarkStringStore_AddRemoveShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.AddRemoveShort, b)
+}
+
+func BenchmarkStringStore_AddRemoveLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.AddRemoveLong, b)
+}
+
+func BenchmarkStringStore_LookupNonExistShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.LookupNonExistShort, b)
+}
+
+func BenchmarkStringStore_LookupNonExistLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.LookupNonExistLong, b)
+}
+
+func BenchmarkStringStore_RemoveNonExistShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.RemoveNonExistShort, b)
+}
+
+func BenchmarkStringStore_RemoveNonExistLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.RemoveNonExistLong, b)
+}
+
+func BenchmarkStringStore_Add1KShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.Add1KShort, b)
+}
+
+func BenchmarkStringStore_Add1KLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.Add1KLong, b)
+}
+
+func BenchmarkStringStore_Lookup1KShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.Lookup1KShort, b)
+}
+
+func BenchmarkStringStore_Lookup1KLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.Lookup1KLong, b)
+}
+
+func BenchmarkStringStore_AddRemove1KShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.AddRemove1KShort, b)
+}
+
+func BenchmarkStringStore_AddRemove1KLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.AddRemove1KLong, b)
+}
+
+func BenchmarkStringStore_LookupNonExist1KShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.LookupNonExist1KShort, b)
+}
+
+func BenchmarkStringStore_LookupNonExist1KLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.LookupNonExist1KLong, b)
+}
+
+func BenchmarkStringStore_RemoveNonExist1KShort(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.RemoveNonExist1KShort, b)
+}
+
+func BenchmarkStringStore_RemoveNonExist1KLong(b *testing.B) {
+	benchmarkHarness(stringStoreBenchmarker.RemoveNonExist1KLong, b)
+}


### PR DESCRIPTION
This implements the `StringStore` using a boltdb and does some cleanup.

Also, these are the benchmark results I get on a relatively new Samsung SSD 850 EVO:

```
BenchmarkStringStore_AddShort-8                     1000           2557951 ns/op
BenchmarkStringStore_AddLong-8                      1000           2637354 ns/op
BenchmarkStringStore_LookupShort-8                500000              3829 ns/op
BenchmarkStringStore_LookupLong-8                 300000              4212 ns/op
BenchmarkStringStore_AddRemoveShort-8                300           5161613 ns/op
BenchmarkStringStore_AddRemoveLong-8                 300           5268226 ns/op
BenchmarkStringStore_LookupNonExistShort-8        300000              3885 ns/op
BenchmarkStringStore_LookupNonExistLong-8         300000              3780 ns/op
BenchmarkStringStore_RemoveNonExistShort-8        100000             11908 ns/op
BenchmarkStringStore_RemoveNonExistLong-8         100000             13119 ns/op
BenchmarkStringStore_Add1KShort-8                    500           2882448 ns/op
BenchmarkStringStore_Add1KLong-8                     500           3206248 ns/op
BenchmarkStringStore_Lookup1KShort-8              500000              5392 ns/op
BenchmarkStringStore_Lookup1KLong-8               200000              9568 ns/op
BenchmarkStringStore_AddRemove1KShort-8              300           4713279 ns/op
BenchmarkStringStore_AddRemove1KLong-8               300           4930794 ns/op
BenchmarkStringStore_LookupNonExist1KShort-8      500000              3915 ns/op
BenchmarkStringStore_LookupNonExist1KLong-8       300000              4845 ns/op
BenchmarkStringStore_RemoveNonExist1KShort-8      200000             11584 ns/op
BenchmarkStringStore_RemoveNonExist1KLong-8       200000             12126 ns/op
```

These, for comparison, are from the `memory` implementation:
```
BenchmarkStringStore_AddShort-8                                          5000000               208 ns/op
BenchmarkStringStore_AddLong-8                                           5000000               274 ns/op
BenchmarkStringStore_LookupShort-8                                      10000000               148 ns/op
BenchmarkStringStore_LookupLong-8                                       10000000               146 ns/op
BenchmarkStringStore_AddRemoveShort-8                                    3000000               416 ns/op
BenchmarkStringStore_AddRemoveLong-8                                     2000000               539 ns/op
BenchmarkStringStore_LookupNonExistShort-8                              10000000               143 ns/op
BenchmarkStringStore_LookupNonExistLong-8                               10000000               141 ns/op
BenchmarkStringStore_RemoveNonExistShort-8                              10000000               166 ns/op
BenchmarkStringStore_RemoveNonExistLong-8                               10000000               166 ns/op
BenchmarkStringStore_Add1KShort-8                                        5000000               238 ns/op
BenchmarkStringStore_Add1KLong-8                                         5000000               315 ns/op
BenchmarkStringStore_Lookup1KShort-8                                    10000000               185 ns/op
BenchmarkStringStore_Lookup1KLong-8                                      5000000               253 ns/op
BenchmarkStringStore_AddRemove1KShort-8                                  3000000               433 ns/op
BenchmarkStringStore_AddRemove1KLong-8                                   3000000               570 ns/op
BenchmarkStringStore_LookupNonExist1KShort-8                            10000000               146 ns/op
BenchmarkStringStore_LookupNonExist1KLong-8                             10000000               146 ns/op
BenchmarkStringStore_RemoveNonExist1KShort-8                            10000000               163 ns/op
BenchmarkStringStore_RemoveNonExist1KLong-8                             10000000               162 ns/op
```

Next up on my list is making a bolt wrapper and benchmarking it with a `memory` backend.