### PR TITLE
http: fix encoding of IPv4 peers with 16-byte addresses

### DIFF
--- a/server/http/writer.go
+++ b/server/http/writer.go
@@ -83,6 +83,9 @@ func writeScrapeResponse(w http.ResponseWriter, resp *chihaya.ScrapeResponse) er
 }
 
 func compact(peer chihaya.Peer) (buf []byte) {
+	if ip := peer.IP.To4(); len(ip) == 4 {
+		peer.IP = ip
+	}
 	buf = []byte(peer.IP)
 	buf = append(buf, byte(peer.Port>>8))
 	buf = append(buf, byte(peer.Port&0xff))


### PR DESCRIPTION
This is a debatable fix/workaround if a PeerStore always returns a 16-byte address, even for IPv4 peers.

Pro: Now behaves the same way for compact and non-compact responses (we us `net.IP.String()` for non-compact, which also detects 16-byte IPv4 addresses)

Con: Not fixing the problem? Maybe we should add a test for PeerStores that verifies that IPv4 peers actually have 4-byte addresses?