### PR TITLE
Parallel benchmarks

### DIFF
--- a/server/store/memory/peer_store_test.go
+++ b/server/store/memory/peer_store_test.go
@@ -13,17 +13,8 @@ import (
 var (
 	peerStoreTester      = store.PreparePeerStoreTester(&peerStoreDriver{})
 	peerStoreBenchmarker = store.PreparePeerStoreBenchmarker(&peerStoreDriver{})
-	peerStoreTestConfig  = &store.DriverConfig{}
+	peerStoreTestConfig  = &store.DriverConfig{Config: peerStoreConfig{Shards: 1024}}
 )
-
-func init() {
-	unmarshalledConfig := struct {
-		Shards int
-	}{
-		1,
-	}
-	peerStoreTestConfig.Config = unmarshalledConfig
-}
 
 func TestPeerStore(t *testing.T) {
 	peerStoreTester.TestPeerStore(t, peerStoreTestConfig)


### PR DESCRIPTION
All benchmarks can now safely be run in parallel using the `-cpu` flag for `go test`.

Also:
- generated infohashes/peers/strings are now random and somewhat evenly distributed


This is what it looks like for the memory peer store:
```
go test -run=NONE -bench=Peer -cpu=1,4
PASS
BenchmarkPeerStore_PutSeeder                                    	 2000000	       557 ns/op
BenchmarkPeerStore_PutSeeder-4                                  	 2000000	       820 ns/op
BenchmarkPeerStore_PutSeeder1KInfohash                          	 2000000	       664 ns/op <
BenchmarkPeerStore_PutSeeder1KInfohash-4                        	 5000000	       244 ns/op < sharding
BenchmarkPeerStore_PutSeeder1KSeeders                           	 2000000	       604 ns/op
BenchmarkPeerStore_PutSeeder1KSeeders-4                         	 1000000	      1171 ns/op
BenchmarkPeerStore_PutSeeder1KInfohash1KSeeders                 	 2000000	       668 ns/op
BenchmarkPeerStore_PutSeeder1KInfohash1KSeeders-4               	 5000000	       248 ns/op
BenchmarkPeerStore_PutDeleteSeeder                              	 1000000	      1799 ns/op
BenchmarkPeerStore_PutDeleteSeeder-4                            	  500000	      2477 ns/op
BenchmarkPeerStore_PutDeleteSeeder1KInfohash                    	 1000000	      1885 ns/op
BenchmarkPeerStore_PutDeleteSeeder1KInfohash-4                  	 2000000	       906 ns/op
BenchmarkPeerStore_PutDeleteSeeder1KSeeders                     	 1000000	      1810 ns/op
BenchmarkPeerStore_PutDeleteSeeder1KSeeders-4                   	 1000000	      1598 ns/op
BenchmarkPeerStore_PutDeleteSeeder1KInfohash1KSeeders           	 1000000	      2003 ns/op
BenchmarkPeerStore_PutDeleteSeeder1KInfohash1KSeeders-4         	 2000000	       858 ns/op
BenchmarkPeerStore_DeleteSeederNonExist                         	 5000000	       390 ns/op
BenchmarkPeerStore_DeleteSeederNonExist-4                       	10000000	       230 ns/op
BenchmarkPeerStore_DeleteSeederNonExist1KInfohash               	 5000000	       383 ns/op
BenchmarkPeerStore_DeleteSeederNonExist1KInfohash-4             	10000000	       121 ns/op
BenchmarkPeerStore_DeleteSeederNonExist1KSeeders                	 5000000	       375 ns/op
BenchmarkPeerStore_DeleteSeederNonExist1KSeeders-4              	10000000	       229 ns/op
BenchmarkPeerStore_DeleteSeederNonExist1KInfohash1KSeeders      	 5000000	       397 ns/op
BenchmarkPeerStore_DeleteSeederNonExist1KInfohash1KSeeders-4    	10000000	       122 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher                     	  500000	      2556 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher-4                   	  300000	      3888 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher1KInfohash           	  500000	      2619 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher1KInfohash-4         	 1000000	      1191 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher1KSeeders            	  500000	      2631 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher1KSeeders-4          	  500000	      3629 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher1KInfohash1KSeeders  	  500000	      2714 ns/op
BenchmarkPeerStore_PutGraduateDeleteLeecher1KInfohash1KSeeders-4	 1000000	      1245 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist                      	 2000000	       613 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist-4                    	 2000000	       667 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist1KInfohash            	 2000000	       691 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist1KInfohash-4          	10000000	       218 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist1KSeeders             	 2000000	       647 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist1KSeeders-4           	 2000000	       689 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist1KInfohash1KSeeders   	 2000000	       708 ns/op
BenchmarkPeerStore_GraduateLeecherNonExist1KInfohash1KSeeders-4 	 5000000	       244 ns/op
BenchmarkPeerStore_AnnouncePeers                                	  100000	     20801 ns/op <
BenchmarkPeerStore_AnnouncePeers-4                              	  200000	      6339 ns/op < RLock
BenchmarkPeerStore_AnnouncePeers1KInfohash                      	   50000	     26422 ns/op
BenchmarkPeerStore_AnnouncePeers1KInfohash-4                    	  200000	      8646 ns/op
BenchmarkPeerStore_AnnouncePeersSeeder                          	  100000	     21227 ns/op
BenchmarkPeerStore_AnnouncePeersSeeder-4                        	  200000	      6694 ns/op
BenchmarkPeerStore_AnnouncePeersSeeder1KInfohash                	   50000	     27341 ns/op
BenchmarkPeerStore_AnnouncePeersSeeder1KInfohash-4              	  200000	      7913 ns/op
BenchmarkPeerStore_GetSeeders                                   	   10000	    183336 ns/op
BenchmarkPeerStore_GetSeeders-4                                 	   20000	     53446 ns/op
BenchmarkPeerStore_GetSeeders1KInfohash                         	   10000	    201986 ns/op
BenchmarkPeerStore_GetSeeders1KInfohash-4                       	   20000	     65234 ns/op
BenchmarkPeerStore_NumSeeders                                   	10000000	       122 ns/op
BenchmarkPeerStore_NumSeeders-4                                 	20000000	        79.0 ns/op
BenchmarkPeerStore_NumSeeders1KInfohash                         	10000000	       167 ns/op
BenchmarkPeerStore_NumSeeders1KInfohash-4                       	20000000	        58.3 ns/op
ok  	github.com/chihaya/chihaya/server/store/memory	155.898s
```

