### PR TITLE
memory: fix garbage collection, add config check

### DIFF
--- a/storage/memory/peer_store_test.go
+++ b/storage/memory/peer_store_test.go
@@ -3,11 +3,13 @@ package memory
 import (
 	"testing"
 
+	"time"
+
 	s "github.com/chihaya/chihaya/storage"
 )
 
 func createNew() s.PeerStore {
-	ps, err := New(Config{ShardCount: 1024})
+	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
GC now uses the `PeerLifetime` field.
I added the `<=0` check because that would send the goroutine to spin on the select. I don't really care if people set `PeerLifetime` to zero, may they collect all their peers...