### PR TITLE
bencode: add missing error handling

### DIFF
--- a/frontend/http/bencode/bencode.go
+++ b/frontend/http/bencode/bencode.go
@@ -2,6 +2,11 @@
 // type assertion over reflection for performance.
 package bencode
 
+import "bytes"
+
+// Enforce that Dict implements the Marshaler interface.
+var _ Marshaler = Dict{}
+
 // Dict represents a bencode dictionary.
 type Dict map[string]interface{}
 
@@ -10,8 +15,25 @@ func NewDict() Dict {
 	return make(Dict)
 }
 
+// MarshalBencode implements the Marshaler interface for Dict.
+func (d Dict) MarshalBencode() ([]byte, error) {
+	var buf bytes.Buffer
+	err := marshalMap(&buf, map[string]interface{}(d))
+	return buf.Bytes(), err
+}
+
+// Enforce that List implements the Marshaler interface.
+var _ Marshaler = List{}
+
 // List represents a bencode list.
 type List []interface{}
+
+// MarshalBencode implements the Marshaler interface for List.
+func (l List) MarshalBencode() ([]byte, error) {
+	var buf bytes.Buffer
+	err := marshalList(&buf, []interface{}(l))
+	return buf.Bytes(), err
+}
 
 // NewList allocates the memory for a List.
 func NewList() List {

--- a/frontend/http/bencode/encoder.go
+++ b/frontend/http/bencode/encoder.go
@@ -25,8 +25,8 @@ func (enc *Encoder) Encode(v interface{}) error {
 
 // Marshal returns the bencoding of v.
 func Marshal(v interface{}) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	err := marshal(buf, v)
+	var buf bytes.Buffer
+	err := marshal(&buf, v)
 	return buf.Bytes(), err
 }
 
@@ -36,124 +36,154 @@ type Marshaler interface {
 	MarshalBencode() ([]byte, error)
 }
 
-// marshal writes types bencoded to an io.Writer
-func marshal(w io.Writer, data interface{}) error {
+// marshal writes types bencoded to an io.Writer.
+func marshal(w io.Writer, data interface{}) (err error) {
 	switch v := data.(type) {
 	case Marshaler:
-		bencoded, err := v.MarshalBencode()
+		var bencoded []byte
+		bencoded, err = v.MarshalBencode()
 		if err != nil {
 			return err
 		}
 		_, err = w.Write(bencoded)
-		if err != nil {
-			return err
-		}
-
-	case string:
-		marshalString(w, v)
-
-	case int:
-		marshalInt(w, int64(v))
-
-	case uint:
-		marshalUint(w, uint64(v))
-
-	case int16:
-		marshalInt(w, int64(v))
-
-	case uint16:
-		marshalUint(w, uint64(v))
-
-	case int32:
-		marshalInt(w, int64(v))
-
-	case uint32:
-		marshalUint(w, uint64(v))
-
-	case int64:
-		marshalInt(w, v)
-
-	case uint64:
-		marshalUint(w, v)
 
 	case []byte:
-		marshalBytes(w, v)
+		err = marshalBytes(w, v)
 
-	case time.Duration: // Assume seconds
-		marshalInt(w, int64(v/time.Second))
-
-	case Dict:
-		marshal(w, map[string]interface{}(v))
-
-	case []Dict:
-		w.Write([]byte{'l'})
-		for _, val := range v {
-			err := marshal(w, val)
-			if err != nil {
-				return err
-			}
-		}
-		w.Write([]byte{'e'})
-
-	case map[string]interface{}:
-		w.Write([]byte{'d'})
-		for key, val := range v {
-			marshalString(w, key)
-			err := marshal(w, val)
-			if err != nil {
-				return err
-			}
-		}
-		w.Write([]byte{'e'})
+	case string:
+		err = marshalString(w, v)
 
 	case []string:
-		w.Write([]byte{'l'})
-		for _, val := range v {
-			err := marshal(w, val)
-			if err != nil {
-				return err
-			}
-		}
-		w.Write([]byte{'e'})
+		err = marshalStringSlice(w, v)
 
-	case List:
-		marshal(w, []interface{}(v))
+	case int:
+		err = marshalInt(w, int64(v))
+
+	case int16:
+		err = marshalInt(w, int64(v))
+
+	case int32:
+		err = marshalInt(w, int64(v))
+
+	case int64:
+		err = marshalInt(w, int64(v))
+
+	case uint:
+		err = marshalUint(w, uint64(v))
+
+	case uint16:
+		err = marshalUint(w, uint64(v))
+
+	case uint32:
+		err = marshalUint(w, uint64(v))
+
+	case uint64:
+		err = marshalUint(w, uint64(v))
+
+	case time.Duration: // Assume seconds
+		err = marshalInt(w, int64(v/time.Second))
+
+	case map[string]interface{}:
+		err = marshalMap(w, v)
 
 	case []interface{}:
-		w.Write([]byte{'l'})
-		for _, val := range v {
-			err := marshal(w, val)
-			if err != nil {
-				return err
-			}
-		}
-		w.Write([]byte{'e'})
+		err = marshalList(w, v)
 
 	default:
 		return fmt.Errorf("attempted to marshal unsupported type:\n%t", v)
 	}
 
-	return nil
+	return err
 }
 
-func marshalInt(w io.Writer, v int64) {
-	w.Write([]byte{'i'})
-	w.Write([]byte(strconv.FormatInt(v, 10)))
-	w.Write([]byte{'e'})
+func marshalInt(w io.Writer, v int64) error {
+	if _, err := w.Write([]byte{'i'}); err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte(strconv.FormatInt(v, 10))); err != nil {
+		return err
+	}
+
+	_, err := w.Write([]byte{'e'})
+	return err
 }
 
-func marshalUint(w io.Writer, v uint64) {
-	w.Write([]byte{'i'})
-	w.Write([]byte(strconv.FormatUint(v, 10)))
-	w.Write([]byte{'e'})
+func marshalUint(w io.Writer, v uint64) error {
+	if _, err := w.Write([]byte{'i'}); err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte(strconv.FormatUint(v, 10))); err != nil {
+		return err
+	}
+
+	_, err := w.Write([]byte{'e'})
+	return err
 }
 
-func marshalBytes(w io.Writer, v []byte) {
-	w.Write([]byte(strconv.Itoa(len(v))))
-	w.Write([]byte{':'})
-	w.Write(v)
+func marshalBytes(w io.Writer, v []byte) error {
+	if _, err := w.Write([]byte(strconv.Itoa(len(v)))); err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte{':'}); err != nil {
+		return err
+	}
+
+	_, err := w.Write(v)
+	return err
 }
 
-func marshalString(w io.Writer, v string) {
-	marshalBytes(w, []byte(v))
+func marshalString(w io.Writer, v string) error {
+	return marshalBytes(w, []byte(v))
+}
+
+func marshalStringSlice(w io.Writer, v []string) error {
+	if _, err := w.Write([]byte{'l'}); err != nil {
+		return err
+	}
+
+	for _, val := range v {
+		if err := marshal(w, val); err != nil {
+			return err
+		}
+	}
+
+	_, err := w.Write([]byte{'e'})
+	return err
+}
+
+func marshalList(w io.Writer, v []interface{}) error {
+	if _, err := w.Write([]byte{'l'}); err != nil {
+		return err
+	}
+
+	for _, val := range v {
+		if err := marshal(w, val); err != nil {
+			return err
+		}
+	}
+
+	_, err := w.Write([]byte{'e'})
+	return err
+}
+
+func marshalMap(w io.Writer, v map[string]interface{}) error {
+	if _, err := w.Write([]byte{'d'}); err != nil {
+		return err
+	}
+
+	for key, val := range v {
+		if err := marshalString(w, key); err != nil {
+			return err
+		}
+
+		if err := marshal(w, val); err != nil {
+			return err
+		}
+	}
+
+	_, err := w.Write([]byte{'e'})
+	return err
 }


### PR DESCRIPTION
Go report card runs `gocyclo -n 15`, while trying to reduce the complexity of some of our calls, I noticed that the bencode encoder is ignoring all the errors from calling `Write`. This is fine if you're working with bytes.Buffer or memory, but if you were to use another instance of an io.Writer, it could fail silently.