### PR TITLE
travis: fix swallowing of exit codes in golint loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 - go test -v $(go list ./... | grep -v /vendor/)
 - go vet $(go list ./... | grep -v /vendor/)
 - diff <(goimports -d $(find . -type f -name '*.go' -not -path "./vendor/*")) <(printf "")
-- for d in $(go list ./... | grep -v /vendor/); do diff <(golint $d) <(printf ""); done
+- (for d in $(go list ./... | grep -v /vendor/); do diff <(golint $d) <(printf "") || exit 1;  done)
 notifications:
   irc:
     channels:


### PR DESCRIPTION
This should fix the non-failed-but-should-have-failed travis build (https://travis-ci.org/chihaya/chihaya/builds/158065317)

The change in bencode is to see if travis fails now, but it might not use the .travis.yml from the PR. Let's see.