### PR TITLE
frontend: add yaml tags to UDP and HTTP configs

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -13,6 +13,9 @@ chihaya:
   udp:
     addr: 0.0.0.0:6881
     allow_ip_spoofing: false
+    max_clock_skew: 10s
+    private_key: |
+      paste a random string here that will be used to hmac connection IDs
 
   storage:
     gc_interval: 14m

--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -47,12 +47,12 @@ func recordResponseDuration(action string, err error, duration time.Duration) {
 // Config represents all of the configurable options for an HTTP BitTorrent
 // Frontend.
 type Config struct {
-	Addr            string
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	RequestTimeout  time.Duration
-	AllowIPSpoofing bool
-	RealIPHeader    string
+	Addr            string        `yaml:"addr"`
+	ReadTimeout     time.Duration `yaml:"read_timeout"`
+	WriteTimeout    time.Duration `yaml:"write_timeout"`
+	RequestTimeout  time.Duration `yaml:"request_timeout"`
+	AllowIPSpoofing bool          `yaml:"allow_ip_spoofing"`
+	RealIPHeader    string        `yaml:"real_ip_header"`
 }
 
 // Frontend holds the state of an HTTP BitTorrent Frontend.

--- a/frontend/udp/frontend.go
+++ b/frontend/udp/frontend.go
@@ -48,10 +48,10 @@ func recordResponseDuration(action string, err error, duration time.Duration) {
 // Config represents all of the configurable options for a UDP BitTorrent
 // Tracker.
 type Config struct {
-	Addr            string
-	PrivateKey      string
-	MaxClockSkew    time.Duration
-	AllowIPSpoofing bool
+	Addr            string        `yaml:"addr"`
+	PrivateKey      string        `yaml:"private_key"`
+	MaxClockSkew    time.Duration `yaml:"max_clock_skew"`
+	AllowIPSpoofing bool          `yaml:"allow_ip_spoofing"`
 }
 
 // Frontend holds the state of a UDP BitTorrent Frontend.


### PR DESCRIPTION
This change also adds the missing fields to the example config.

Fixes #228.