### PR TITLE
dockerfile: delete the compiler from the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ ADD . /go/src/github.com/chihaya/chihaya
 RUN glide install
 RUN go install github.com/chihaya/chihaya/cmd/chihaya
 
+# Delete the compiler from the container.
+# This makes the container much smaller when using Quay's squashing feature.
+RUN rm -r /usr/local/go
+
 # Expose a docker interface to our binary.
 EXPOSE 6880 6881
 ENTRYPOINT ["chihaya"]


### PR DESCRIPTION
This drastically shrinks the size of the container when deploying using
Quay's squashed image support.

https://docs.quay.io/guides/squashed-images.html