### PR TITLE
middleware: add deniability

### DIFF
--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -11,6 +11,7 @@ import (
 	udpfrontend "github.com/chihaya/chihaya/frontend/udp"
 	"github.com/chihaya/chihaya/middleware"
 	"github.com/chihaya/chihaya/middleware/clientapproval"
+	"github.com/chihaya/chihaya/middleware/deniability"
 	"github.com/chihaya/chihaya/middleware/jwt"
 	"github.com/chihaya/chihaya/middleware/varinterval"
 	"github.com/chihaya/chihaya/storage/memory"
@@ -104,6 +105,17 @@ func (cfg ConfigFile) CreateHooks() (preHooks, postHooks []middleware.Hook, err 
 			hook, err := varinterval.New(viCfg)
 			if err != nil {
 				return nil, nil, errors.New("invalid interval variation middleware config: " + err.Error())
+			}
+			preHooks = append(preHooks, hook)
+		case "deniability":
+			var hCfg deniability.Config
+			err := yaml.Unmarshal(cfgBytes, &hCfg)
+			if err != nil {
+				return nil, nil, errors.New("invalid deniability middleware config: " + err.Error())
+			}
+			hook, err := deniability.New(hCfg)
+			if err != nil {
+				return nil, nil, errors.New("invalid deniability middleware config: " + err.Error())
 			}
 			preHooks = append(preHooks, hook)
 		}

--- a/docs/middleware/deniability.md
+++ b/docs/middleware/deniability.md
@@ -1,29 +1,23 @@
 # Deniability Middleware
 
-This package provides the PreHook `deniability` which inserts ghost peers into announce responses and increases scrape counters to achieve plausible deniability.
+This package provides the PreHook `deniability` which inserts ghost peers into announce responses to achieve plausible deniability.
 
 ## Functionality
 
 ### For Announces
 
 This middleware will choose random announces and modify the list of peers returned.
-A random number of randomly generated peers will be inserted at random positions into the list of peers.
-As soon as the length of the list of peers exceeds `numWant`, peers will be replaced rather than inserted.
+A random number *k* of randomly generated peers will be inserted at random positions into the list of peers.
+Peers will only be inserted until there is only space for one more Peer or *k* Peers have been inserted. 
 
 Also note that the IP address for the generated peeer consists of bytes in the range [1,254].
 Whether IPv4 or IPv6 addresses are generated depends on the announcing Peer's IP.
 
 Note that if a response is picked for augmentation, at least one Peer will be inserted.
-There is one exception to this rule:
-Otherwise empty reponse will not be augmented to make it more difficult to determine the prefixes used for generated Peers.
 
 ### For Scrapes
 
-A scrape will randomly be chosen, based on the `modify_response_probability`.
-If chosen, a number of seeders and leechers will be generated for every InfoHash of the scrape.
-
-Note that there will be at least one peer added to every InfoHash, this can be either a seeder or a leecher.
-As with Announces, the only exception to this rule are otherwise empty scrapes.
+Scrapes are not altered.
 
 ## Configuration
 
@@ -35,8 +29,6 @@ This middleware provides the following parameters for configuration:
     The peer ID will be padded to 20 bytes using a random string of numeric characters.
 - `min_port` (int, >0, <=65535) sets a lower boundary for the port for generated peers.
 - `max_port` (int, >0, <=65536, > `min_port`) sets an upper boundary for the port for generated peers.
-- `parallelism` (int, >=0) determines the amount of parallelism this hook can operate with.
-    The resulting theoretical upper limit of parallelism is `2^parallelism)`, assuming an even random distribution of infohashes.
 
 An example config might look like this:
 
@@ -45,12 +37,12 @@ chihaya:
   prehooks:
     - name: deniability
       config:
-        modify_response_probability: 0.2
+        modify_response_probability: 0.01
         max_random_peers: 5
-        prefix: -AZ2060-
-        min_port: 40000
+        prefix: OP1011-
+        min_port: 10000
         max_port: 60000
-        parallelism: 8
 ```
+
 
 For more information about peer IDs and their prefixes, see [this wiki entry](https://wiki.theory.org/BitTorrentSpecification#peer_id).

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -42,6 +42,13 @@ chihaya:
       modify_response_probability: 0.2
       max_increase_delta: 60
       modify_min_interval: true
+  - name: deniability
+    config:
+      modify_response_probability: 0.01
+      max_random_peers: 5
+      prefix: OP1011-
+      min_port: 10000
+      max_port: 60000
 
   posthooks:
   - name: gossip

--- a/middleware/deniability/deniability.go
+++ b/middleware/deniability/deniability.go
@@ -1,0 +1,211 @@
+package deniability
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"net"
+
+	"github.com/chihaya/chihaya/bittorrent"
+	"github.com/chihaya/chihaya/middleware"
+	"github.com/chihaya/chihaya/pkg/prand"
+)
+
+// ErrInvalidModifyResponseProbability is returned for a config with an invalid
+// modify_response_probability.
+var ErrInvalidModifyResponseProbability = errors.New("invalid modify_response_probability")
+
+// ErrInvalidMaxRandomPeers is returned for a config with an invalid
+// max_random_peers.
+var ErrInvalidMaxRandomPeers = errors.New("invalid max_random_peers")
+
+// ErrInvalidPrefix is returned for a config with an invalid prefix.
+var ErrInvalidPrefix = errors.New("invalid prefix")
+
+// ErrInvalidMaxPort is returned for a config with an invalid max_port.
+var ErrInvalidMaxPort = errors.New("invalid max_port")
+
+// ErrInvalidMinPort is returned for a config with an invalid min_port.
+var ErrInvalidMinPort = errors.New("invalid min_port")
+
+// Config represents the configuration for the deniability middleware.
+type Config struct {
+	// ModifyResponseProbability is the probability by which a response will
+	// be augmented with random peers.
+	ModifyResponseProbability float32 `yaml:"modify_response_probability"`
+
+	// MaxRandomPeers is the amount of peers that will be added at most.
+	MaxRandomPeers int `yaml:"max_random_peers"`
+
+	// Prefix is the prefix to be used for peer IDs.
+	Prefix string `yaml:"prefix"`
+
+	// MinPort is the minimum port (inclusive) for the generated peer.
+	MinPort uint16 `yaml:"min_port"`
+
+	// MaxPort is the maximum port (exclusive) for the generated peer.
+	MaxPort int `yaml:"max_port"`
+}
+
+type hook struct {
+	cfg Config
+	pr  *prand.Container
+}
+
+func checkConfig(cfg Config) error {
+	if cfg.ModifyResponseProbability > 1 || cfg.ModifyResponseProbability <= 0 {
+		return ErrInvalidModifyResponseProbability
+	}
+
+	if cfg.MaxRandomPeers <= 0 {
+		return ErrInvalidMaxRandomPeers
+	}
+
+	if len(cfg.Prefix) > 20 {
+		return ErrInvalidPrefix
+	}
+
+	if cfg.MinPort == 0 {
+		return ErrInvalidMinPort
+	}
+
+	if cfg.MaxPort <= int(cfg.MinPort) || cfg.MaxPort > 65536 {
+		return ErrInvalidMaxPort
+	}
+
+	return nil
+}
+
+// New creates a new deniability hook from the given config.
+func New(cfg Config) (middleware.Hook, error) {
+	err := checkConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	toReturn := &hook{
+		cfg: cfg,
+		pr:  prand.New(1024),
+	}
+
+	return toReturn, nil
+}
+
+func (h *hook) HandleAnnounce(ctx context.Context, req *bittorrent.AnnounceRequest, resp *bittorrent.AnnounceResponse) (context.Context, error) {
+	var (
+		peers *[]bittorrent.Peer
+		v6    bool
+	)
+
+	switch req.IP.AddressFamily {
+	case bittorrent.IPv4:
+		peers = &resp.IPv4Peers
+	case bittorrent.IPv6:
+		v6 = true
+		peers = &resp.IPv6Peers
+	default:
+		panic("Peer's IP is neither IPv4 nor IPv6")
+	}
+
+	r := h.pr.GetByInfohash(req.InfoHash)
+	if h.cfg.ModifyResponseProbability == 1 || r.Float32() < h.cfg.ModifyResponseProbability {
+		numNewPeers := r.Intn(h.cfg.MaxRandomPeers) + 1
+
+		// Insert up to numNewPeers, but always leave space for at least
+		// one real peer!
+		for i := 0; i < numNewPeers && uint32(len(*peers)) < req.NumWant; i++ {
+			*peers = h.insertPeer(*peers, v6, r)
+		}
+	}
+	h.pr.ReturnByInfohash(req.InfoHash)
+
+	return ctx, nil
+}
+
+// insertPeer inserts a randomly generated peer at a random position into the
+// given slice and returns the new slice.
+func (h *hook) insertPeer(peers []bittorrent.Peer, v6 bool, r *rand.Rand) []bittorrent.Peer {
+	pos := 0
+	if len(peers) > 0 {
+		pos = r.Intn(len(peers))
+	}
+	peers = append(peers, bittorrent.Peer{})
+	copy(peers[pos+1:], peers[pos:])
+	peers[pos] = randomPeer(r, h.cfg.Prefix, v6, h.cfg.MinPort, h.cfg.MaxPort)
+
+	return peers
+}
+
+func (h *hook) HandleScrape(ctx context.Context, req *bittorrent.ScrapeRequest, resp *bittorrent.ScrapeResponse) (context.Context, error) {
+	// Nothing to do for scrapes.
+	return ctx, nil
+}
+
+// randomPeer generates a random bittorrent.Peer.
+//
+// prefix is the prefix to use for the peer ID. If len(prefix) > 20, it will be
+// truncated to 20 characters. If len(prefix) < 20, it will be padded with a
+// numeric random string to have 20 characters. This matches the general style
+// of PeerIDs: A prefix unique to a client (the ClientID) followed by a string
+// of random numbers.
+//
+// v6 indicates whether an IPv6 address should be generated.
+// Regardless of the length of the generated IP address, its bytes will have
+// values in [1,254].
+//
+// minPort and maxPort describe the range for the randomly generated port, where
+// minPort <= port < maxPort.
+// minPort and maxPort will be checked and altered so that
+// 1 <= minPort <= maxPort <= 65536.
+// If minPort == maxPort, the port will be set to minPort.
+func randomPeer(r *rand.Rand, prefix string, v6 bool, minPort uint16, maxPort int) bittorrent.Peer {
+	var port uint16
+
+	if maxPort > 65536 {
+		maxPort = 65536
+	}
+	if maxPort < int(minPort) {
+		maxPort = int(minPort)
+	}
+	if len(prefix) > 20 {
+		prefix = prefix[:20]
+	}
+
+	if int(minPort) == maxPort {
+		port = minPort
+	} else {
+		port = uint16(r.Intn(maxPort-int(minPort))) + minPort
+	}
+
+	bIP := bittorrent.IP{}
+	if v6 {
+		bIP.IP = make(net.IP, net.IPv6len)
+		bIP.AddressFamily = bittorrent.IPv6
+	} else {
+		bIP.IP = make(net.IP, net.IPv4len)
+		bIP.AddressFamily = bittorrent.IPv4
+	}
+
+	for i := range bIP.IP {
+		b := r.Intn(254) + 1
+		bIP.IP[i] = byte(b)
+	}
+
+	prefix = prefix + numericString(r, 20-len(prefix))
+
+	return bittorrent.Peer{
+		ID:   bittorrent.PeerIDFromString(prefix),
+		Port: port,
+		IP:   bIP,
+	}
+}
+
+const numbers = "0123456789"
+
+func numericString(r *rand.Rand, l int) string {
+	b := make([]byte, l)
+	for i := range b {
+		b[i] = numbers[r.Intn(len(numbers))]
+	}
+	return string(b)
+}

--- a/middleware/deniability/deniability_test.go
+++ b/middleware/deniability/deniability_test.go
@@ -1,0 +1,144 @@
+package deniability
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/chihaya/chihaya/bittorrent"
+)
+
+type configTestDatum struct {
+	cfg      Config
+	expected error
+}
+
+var configTestData = []configTestDatum{
+	{
+		cfg:      Config{1.0, 50, "TEST", 1025, 65536},
+		expected: nil,
+	}, {
+		cfg:      Config{1.0, 5, "", 1, 65536},
+		expected: nil,
+	}, {
+		cfg:      Config{0, 5, "TEST", 1025, 65536},
+		expected: ErrInvalidModifyResponseProbability,
+	}, {
+		cfg:      Config{1.0, 5, "TEST", 0, 65536},
+		expected: ErrInvalidMinPort,
+	}, {
+		cfg:      Config{1.0, 5, "TEST", 1025, 1024},
+		expected: ErrInvalidMaxPort,
+	}, {
+		cfg:      Config{1.0, 5, "TEST", 1025, 100000},
+		expected: ErrInvalidMaxPort,
+	}, {
+		cfg:      Config{1.0, 5, "01234567890123456789_", 1025, 65536},
+		expected: ErrInvalidPrefix,
+	},
+}
+
+func TestCheckConfig(t *testing.T) {
+	for _, d := range configTestData {
+		got := checkConfig(d.cfg)
+		require.Equal(t, d.expected, got, "", fmt.Sprintf("%+v", d.cfg))
+	}
+}
+
+func TestNew(t *testing.T) {
+	hook, err := New(configTestData[0].cfg)
+	require.Nil(t, err)
+	require.NotNil(t, hook)
+}
+
+func TestHook_HandleAnnounce(t *testing.T) {
+	knownPeerID := bittorrent.PeerIDFromString("00000000001111111111")
+	req := &bittorrent.AnnounceRequest{NumWant: 50, Peer: bittorrent.Peer{IP: bittorrent.IP{IP: net.IP([]byte{1, 2, 3, 4}), AddressFamily: bittorrent.IPv4}}}
+	resp := &bittorrent.AnnounceResponse{IPv4Peers: []bittorrent.Peer{{ID: knownPeerID, IP: bittorrent.IP{IP: net.IP([]byte{2, 3, 4, 5}), AddressFamily: bittorrent.IPv4}}}}
+	cfg := configTestData[0].cfg
+
+	hook, err := New(cfg)
+	require.Nil(t, err)
+	ctx := context.Background()
+	nCtx, err := hook.HandleAnnounce(ctx, req, resp)
+	require.Nil(t, err)
+	require.Equal(t, ctx, nCtx)
+
+	require.True(t, len(resp.IPv4Peers) > 1)
+	for _, peer := range resp.IPv4Peers {
+		if bytes.Equal(peer.ID[:], knownPeerID[:]) {
+			continue
+		}
+
+		require.Equal(t, len(req.Peer.IP.IP), len(peer.IP.IP))
+		require.Equal(t, cfg.Prefix, string(peer.ID[:len(cfg.Prefix)]))
+		require.True(t, int(peer.Port) < cfg.MaxPort)
+		require.True(t, peer.Port >= cfg.MinPort)
+	}
+}
+
+// manyPeers returns 50 Peers
+func makePeers() []bittorrent.Peer {
+	return []bittorrent.Peer{{}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		{}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		{}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		{}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		{}, {}, {}, {}, {}, {}, {}, {}, {}, {}}
+}
+
+func makeBenchmark(b *testing.B, cfg Config, v6, manyPeers bool) func(b *testing.B) {
+	req := &bittorrent.AnnounceRequest{NumWant: 50, Peer: bittorrent.Peer{ID: bittorrent.PeerIDFromString("12345678901234567890"), IP: bittorrent.IP{IP: net.IP([]byte{1, 2, 3, 4}), AddressFamily: bittorrent.IPv4}}}
+	resp := &bittorrent.AnnounceResponse{}
+	if v6 {
+		req.Peer.IP.IP = net.ParseIP("2001:db8::68")
+		req.Peer.IP.AddressFamily = bittorrent.IPv6
+	}
+	if manyPeers {
+		if v6 {
+			resp.IPv6Peers = makePeers()
+		} else {
+			resp.IPv4Peers = makePeers()
+		}
+	}
+
+	hook, err := New(cfg)
+	require.Nil(b, err)
+	ctx := context.Background()
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			hook.HandleAnnounce(ctx, req, resp)
+			if !manyPeers {
+				// Reset this, fills up otherwise.
+				// We can not set them to nil, the hook ignores
+				// empty responses.
+				resp.IPv4Peers = []bittorrent.Peer{{}}
+				resp.IPv6Peers = []bittorrent.Peer{{}}
+			}
+		}
+	}
+}
+
+func BenchmarkHook_HandleAnnounce(b *testing.B) {
+	cfg := configTestData[0].cfg
+	chances := []float32{0.1, 0.25, 0.5, 1}
+	max := []int{1, 5, 10, 50}
+	bools := []bool{false, true}
+	for _, c := range chances {
+		for _, m := range max {
+			for _, ipv6 := range bools {
+				for _, manyPeers := range bools {
+					// If we have manyPeers the hook will replace instead of inserting.
+					cfg.MaxRandomPeers = m
+					cfg.ModifyResponseProbability = c
+					b.Run(fmt.Sprintf("modify=%f, max=%d, ipv6=%t, replace=%t", c, m, ipv6, manyPeers),
+						makeBenchmark(b, cfg, ipv6, manyPeers))
+				}
+			}
+		}
+	}
+}

--- a/middleware/hooks.go
+++ b/middleware/hooks.go
@@ -167,9 +167,15 @@ func (h *responseHook) appendPeers(req *bittorrent.AnnounceRequest, resp *bittor
 
 	switch req.IP.AddressFamily {
 	case bittorrent.IPv4:
-		resp.IPv4Peers = peers
+		resp.IPv4Peers = append(resp.IPv4Peers, peers...)
+		if uint32(len(resp.IPv4Peers)) > req.NumWant {
+			resp.IPv4Peers = resp.IPv4Peers[:req.NumWant]
+		}
 	case bittorrent.IPv6:
-		resp.IPv6Peers = peers
+		resp.IPv6Peers = append(resp.IPv6Peers, peers...)
+		if uint32(len(resp.IPv6Peers)) > req.NumWant {
+			resp.IPv6Peers = resp.IPv6Peers[:req.NumWant]
+		}
 	default:
 		panic("attempted to append peer that is neither IPv4 nor IPv6")
 	}


### PR DESCRIPTION
I ported and upgraded the deniability middleware from v1.x.
It works, but it needs to run after the response hook for two reasons:

1. The response hook overwrites whatever it finds in the peer lists
2. As explained in the README, we want to handle empty responses differently from non-empty ones.

Also I need to move the documentation out of this to the new docs repo. But take a look at the code first, please.

Also, this is what the benchmarks look like:
```
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=1,_ipv6=false,_replace=false         	 5000000	       274 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=1,_ipv6=false,_replace=true          	10000000	       137 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=1,_ipv6=true,_replace=false          	 5000000	       307 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=1,_ipv6=true,_replace=true           	10000000	       171 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=5,_ipv6=false,_replace=false         	 3000000	       466 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=5,_ipv6=false,_replace=true          	 5000000	       292 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=5,_ipv6=true,_replace=false          	 3000000	       558 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=5,_ipv6=true,_replace=true           	 5000000	       384 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=10,_ipv6=false,_replace=false        	 2000000	       694 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=10,_ipv6=false,_replace=true         	 3000000	       484 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=10,_ipv6=true,_replace=false         	 2000000	       876 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=10,_ipv6=true,_replace=true          	 2000000	       652 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=50,_ipv6=false,_replace=false        	  500000	      2551 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=50,_ipv6=false,_replace=true         	 1000000	      2010 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=50,_ipv6=true,_replace=false         	  500000	      3366 ns/op
BenchmarkHook_HandleAnnounce/modify=0.100000,_max=50,_ipv6=true,_replace=true          	  500000	      2795 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=1,_ipv6=false,_replace=false         	 3000000	       426 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=1,_ipv6=false,_replace=true          	 5000000	       261 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=1,_ipv6=true,_replace=false          	 3000000	       512 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=1,_ipv6=true,_replace=true           	 5000000	       346 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=5,_ipv6=false,_replace=false         	 2000000	       903 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=5,_ipv6=false,_replace=true          	 2000000	       662 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=5,_ipv6=true,_replace=false          	 1000000	      1158 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=5,_ipv6=true,_replace=true           	 2000000	       894 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=10,_ipv6=false,_replace=false        	 1000000	      1516 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=10,_ipv6=false,_replace=true         	 1000000	      1131 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=10,_ipv6=true,_replace=false         	 1000000	      1956 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=10,_ipv6=true,_replace=true          	 1000000	      1565 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=50,_ipv6=false,_replace=false        	  200000	      6318 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=50,_ipv6=false,_replace=true         	  300000	      4953 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=50,_ipv6=true,_replace=false         	  200000	      8242 ns/op
BenchmarkHook_HandleAnnounce/modify=0.250000,_max=50,_ipv6=true,_replace=true          	  200000	      7093 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=1,_ipv6=false,_replace=false         	 2000000	       742 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=1,_ipv6=false,_replace=true          	 3000000	       472 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=1,_ipv6=true,_replace=false          	 2000000	       835 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=1,_ipv6=true,_replace=true           	 2000000	       616 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=5,_ipv6=false,_replace=false         	 1000000	      1603 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=5,_ipv6=false,_replace=true          	 1000000	      1219 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=5,_ipv6=true,_replace=false          	 1000000	      2064 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=5,_ipv6=true,_replace=true           	 1000000	      1690 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=10,_ipv6=false,_replace=false        	  500000	      2734 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=10,_ipv6=false,_replace=true         	 1000000	      2183 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=10,_ipv6=true,_replace=false         	  500000	      3674 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=10,_ipv6=true,_replace=true          	  500000	      3097 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=50,_ipv6=false,_replace=false        	  100000	     12336 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=50,_ipv6=false,_replace=true         	  200000	      9838 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=50,_ipv6=true,_replace=false         	  100000	     16193 ns/op
BenchmarkHook_HandleAnnounce/modify=0.500000,_max=50,_ipv6=true,_replace=true          	  100000	     14009 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=1,_ipv6=false,_replace=false         	 1000000	      1127 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=1,_ipv6=false,_replace=true          	 2000000	       810 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=1,_ipv6=true,_replace=false          	 1000000	      1429 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=1,_ipv6=true,_replace=true           	 1000000	      1153 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=5,_ipv6=false,_replace=false         	  500000	      2984 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=5,_ipv6=false,_replace=true          	 1000000	      2402 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=5,_ipv6=true,_replace=false          	  300000	      3910 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=5,_ipv6=true,_replace=true           	  500000	      3361 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=10,_ipv6=false,_replace=false        	  300000	      5320 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=10,_ipv6=false,_replace=true         	  300000	      4260 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=10,_ipv6=true,_replace=false         	  200000	      7022 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=10,_ipv6=true,_replace=true          	  200000	      5960 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=50,_ipv6=false,_replace=false        	  100000	     23662 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=50,_ipv6=false,_replace=true         	  100000	     19289 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=50,_ipv6=true,_replace=false         	   50000	     31567 ns/op
BenchmarkHook_HandleAnnounce/modify=1.000000,_max=50,_ipv6=true,_replace=true          	   50000	     27531 ns/op
```