### PR TITLE
middleware: add sanitization hook

### DIFF
--- a/bittorrent/bittorrent.go
+++ b/bittorrent/bittorrent.go
@@ -110,11 +110,26 @@ type Scrape struct {
 	Incomplete uint32
 }
 
+// AddressFamily is the address family of an IP address.
+type AddressFamily uint8
+
+// AddressFamily constants.
+const (
+	IPv4 AddressFamily = iota
+	IPv6
+)
+
+// IP is a net.IP with an AddressFamily.
+type IP struct {
+	net.IP
+	AddressFamily
+}
+
 // Peer represents the connection details of a peer that is returned in an
 // announce response.
 type Peer struct {
 	ID   PeerID
-	IP   net.IP
+	IP   IP
 	Port uint16
 }
 
@@ -122,7 +137,7 @@ type Peer struct {
 func (p Peer) Equal(x Peer) bool { return p.EqualEndpoint(x) && p.ID == x.ID }
 
 // EqualEndpoint reports whether p and x have the same endpoint.
-func (p Peer) EqualEndpoint(x Peer) bool { return p.Port == x.Port && p.IP.Equal(x.IP) }
+func (p Peer) EqualEndpoint(x Peer) bool { return p.Port == x.Port && p.IP.Equal(x.IP.IP) }
 
 // ClientError represents an error that should be exposed to the client over
 // the BitTorrent protocol implementation.

--- a/bittorrent/bittorrent.go
+++ b/bittorrent/bittorrent.go
@@ -94,8 +94,9 @@ type AnnounceResponse struct {
 
 // ScrapeRequest represents the parsed parameters from a scrape request.
 type ScrapeRequest struct {
-	InfoHashes []InfoHash
-	Params     Params
+	AddressFamily AddressFamily
+	InfoHashes    []InfoHash
+	Params        Params
 }
 
 // ScrapeResponse represents the parameters used to create a scrape response.

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,6 +1,8 @@
 chihaya:
   announce_interval: 15m
   prometheus_addr: localhost:6880
+  max_numwant: 50
+  default_numwant: 25
 
   http:
     addr: 0.0.0.0:6881
@@ -21,7 +23,6 @@ chihaya:
     gc_interval: 14m
     peer_lifetime: 15m
     shards: 1
-    max_numwant: 100
 
   prehooks:
   - name: jwt

--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/chihaya/chihaya/bittorrent"
 	"github.com/chihaya/chihaya/frontend"
-	"github.com/chihaya/chihaya/middleware"
 )
 
 func init() {
@@ -177,20 +176,17 @@ func (t *Frontend) scrapeRoute(w http.ResponseWriter, r *http.Request, _ httprou
 	}
 
 	reqIP := net.ParseIP(host)
-	af := bittorrent.IPv4
 	if reqIP.To4() != nil {
-		af = bittorrent.IPv4
+		req.AddressFamily = bittorrent.IPv4
 	} else if len(reqIP) == net.IPv6len { // implies reqIP.To4() == nil
-		af = bittorrent.IPv6
+		req.AddressFamily = bittorrent.IPv6
 	} else {
 		log.Errorln("http: invalid IP: neither v4 nor v6, RemoteAddr was", r.RemoteAddr)
 		WriteError(w, ErrInvalidIP)
 		return
 	}
 
-	ctx := context.WithValue(context.Background(), middleware.ScrapeIsIPv6Key, af == bittorrent.IPv6)
-
-	resp, err := t.logic.HandleScrape(ctx, req)
+	resp, err := t.logic.HandleScrape(context.Background(), req)
 	if err != nil {
 		WriteError(w, err)
 		return

--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tylerb/graceful"
 
+	"github.com/chihaya/chihaya/bittorrent"
 	"github.com/chihaya/chihaya/frontend"
 	"github.com/chihaya/chihaya/middleware"
 )
@@ -21,6 +22,9 @@ func init() {
 	prometheus.MustRegister(promResponseDurationMilliseconds)
 	recordResponseDuration("action", nil, time.Second)
 }
+
+// ErrInvalidIP indicates an invalid IP.
+var ErrInvalidIP = bittorrent.ClientError("invalid IP")
 
 var promResponseDurationMilliseconds = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
@@ -172,8 +176,19 @@ func (t *Frontend) scrapeRoute(w http.ResponseWriter, r *http.Request, _ httprou
 		return
 	}
 
-	ip := net.ParseIP(host)
-	ctx := context.WithValue(context.Background(), middleware.ScrapeIsIPv6Key, len(ip) == net.IPv6len)
+	reqIP := net.ParseIP(host)
+	af := bittorrent.IPv4
+	if reqIP.To4() != nil {
+		af = bittorrent.IPv4
+	} else if len(reqIP) == net.IPv6len { // implies reqIP.To4() == nil
+		af = bittorrent.IPv6
+	} else {
+		log.Errorln("http: invalid IP: neither v4 nor v6, RemoteAddr was", r.RemoteAddr)
+		WriteError(w, ErrInvalidIP)
+		return
+	}
+
+	ctx := context.WithValue(context.Background(), middleware.ScrapeIsIPv6Key, af == bittorrent.IPv6)
 
 	resp, err := t.logic.HandleScrape(ctx, req)
 	if err != nil {

--- a/frontend/http/parser.go
+++ b/frontend/http/parser.go
@@ -74,14 +74,9 @@ func ParseAnnounce(r *http.Request, realIPHeader string, allowIPSpoofing bool) (
 	}
 	request.Peer.Port = uint16(port)
 
-	request.Peer.IP = requestedIP(r, qp, realIPHeader, allowIPSpoofing)
-	if request.Peer.IP == nil {
+	request.Peer.IP.IP = requestedIP(r, qp, realIPHeader, allowIPSpoofing)
+	if request.Peer.IP.IP == nil {
 		return nil, bittorrent.ClientError("failed to parse peer IP address")
-	}
-
-	// Sanitize IPv4 addresses to 4 bytes.
-	if ip := request.Peer.IP.To4(); ip != nil {
-		request.Peer.IP = ip
 	}
 
 	return request, nil

--- a/frontend/udp/parser.go
+++ b/frontend/udp/parser.go
@@ -29,10 +29,6 @@ var (
 	// initialConnectionID is the magic initial connection ID specified by BEP 15.
 	initialConnectionID = []byte{0, 0, 0x04, 0x17, 0x27, 0x10, 0x19, 0x80}
 
-	// emptyIPs are the value of an IP field that has been left blank.
-	emptyIPv4 = []byte{0, 0, 0, 0}
-	emptyIPv6 = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-
 	// eventIDs map values described in BEP 15 to Events.
 	eventIDs = []bittorrent.Event{
 		bittorrent.None,
@@ -105,7 +101,7 @@ func ParseAnnounce(r Request, allowIPSpoofing, v6 bool) (*bittorrent.AnnounceReq
 		Uploaded:   uploaded,
 		Peer: bittorrent.Peer{
 			ID:   bittorrent.PeerIDFromBytes(peerID),
-			IP:   ip,
+			IP:   bittorrent.IP{IP: ip},
 			Port: port,
 		},
 		Params: params,

--- a/frontend/udp/writer.go
+++ b/frontend/udp/writer.go
@@ -46,7 +46,7 @@ func WriteAnnounce(w io.Writer, txID []byte, resp *bittorrent.AnnounceResponse, 
 	}
 
 	for _, peer := range peers {
-		buf.Write(peer.IP)
+		buf.Write(peer.IP.IP)
 		binary.Write(buf, binary.BigEndian, peer.Port)
 	}
 

--- a/middleware/hooks.go
+++ b/middleware/hooks.go
@@ -182,14 +182,8 @@ func (h *responseHook) HandleScrape(ctx context.Context, req *bittorrent.ScrapeR
 		return ctx, nil
 	}
 
-	v6, _ := ctx.Value(ScrapeIsIPv6Key).(bool)
-
 	for _, infoHash := range req.InfoHashes {
-		if v6 {
-			resp.Files[infoHash] = h.store.ScrapeSwarm(infoHash, bittorrent.IPv6)
-		} else {
-			resp.Files[infoHash] = h.store.ScrapeSwarm(infoHash, bittorrent.IPv4)
-		}
+		resp.Files[infoHash] = h.store.ScrapeSwarm(infoHash, req.AddressFamily)
 	}
 
 	return ctx, nil

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/chihaya/chihaya/bittorrent"
+)
+
+// nopHook is a Hook to measure the overhead of a no-operation Hook through
+// benchmarks.
+type nopHook struct{}
+
+func (h *nopHook) HandleAnnounce(ctx context.Context, req *bittorrent.AnnounceRequest, resp *bittorrent.AnnounceResponse) (context.Context, error) {
+	return ctx, nil
+}
+
+func (h *nopHook) HandleScrape(ctx context.Context, req *bittorrent.ScrapeRequest, resp *bittorrent.ScrapeResponse) (context.Context, error) {
+	return ctx, nil
+}
+
+type hookList []Hook
+
+func (hooks hookList) handleAnnounce(ctx context.Context, req *bittorrent.AnnounceRequest) (resp *bittorrent.AnnounceResponse, err error) {
+	resp = &bittorrent.AnnounceResponse{
+		Interval:    60,
+		MinInterval: 60,
+		Compact:     true,
+	}
+
+	for _, h := range []Hook(hooks) {
+		if ctx, err = h.HandleAnnounce(ctx, req, resp); err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}
+
+func benchHookListV4(b *testing.B, hooks hookList) {
+	req := &bittorrent.AnnounceRequest{Peer: bittorrent.Peer{IP: bittorrent.IP{IP: net.ParseIP("1.2.3.4"), AddressFamily: bittorrent.IPv4}}}
+	benchHookList(b, hooks, req)
+}
+
+func benchHookListV6(b *testing.B, hooks hookList) {
+	req := &bittorrent.AnnounceRequest{Peer: bittorrent.Peer{IP: bittorrent.IP{IP: net.ParseIP("fc00::0001"), AddressFamily: bittorrent.IPv6}}}
+	benchHookList(b, hooks, req)
+}
+
+func benchHookList(b *testing.B, hooks hookList, req *bittorrent.AnnounceRequest) {
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := hooks.handleAnnounce(ctx, req)
+		require.Nil(b, err)
+		require.NotNil(b, resp)
+	}
+}
+
+func BenchmarkHookOverhead(b *testing.B) {
+	b.Run("none-v4", func(b *testing.B) {
+		benchHookListV4(b, hookList{})
+	})
+
+	b.Run("none-v6", func(b *testing.B) {
+		benchHookListV6(b, hookList{})
+	})
+
+	var nopHooks hookList
+	for i := 1; i < 4; i++ {
+		nopHooks = append(nopHooks, &nopHook{})
+		b.Run(fmt.Sprintf("%dnop-v4", i), func(b *testing.B) {
+			benchHookListV4(b, nopHooks)
+		})
+		b.Run(fmt.Sprintf("%dnop-v6", i), func(b *testing.B) {
+			benchHookListV6(b, nopHooks)
+		})
+	}
+
+	var sanHooks hookList
+	for i := 1; i < 4; i++ {
+		sanHooks = append(sanHooks, &sanitizationHook{maxNumWant: 50})
+		b.Run(fmt.Sprintf("%dsanitation-v4", i), func(b *testing.B) {
+			benchHookListV4(b, sanHooks)
+		})
+		b.Run(fmt.Sprintf("%dsanitation-v6", i), func(b *testing.B) {
+			benchHookListV6(b, sanHooks)
+		})
+	}
+}

--- a/storage/memory/peer_store_test.go
+++ b/storage/memory/peer_store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func createNew() s.PeerStore {
-	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute, MaxNumWant: 50})
+	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute})
 	if err != nil {
 		panic(err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -57,13 +57,13 @@ type PeerStore interface {
 
 	// ScrapeSwarm returns information required to answer a scrape request
 	// about a swarm identified by the given infohash.
-	// The v6 flag indicates whether or not the IPv6 swarm should be
+	// The AddressFamily indicates whether or not the IPv6 swarm should be
 	// scraped.
 	// The Complete and Incomplete fields of the Scrape must be filled,
 	// filling the Snatches field is optional.
 	// If the infohash is unknown to the PeerStore, an empty Scrape is
 	// returned.
-	ScrapeSwarm(infoHash bittorrent.InfoHash, v6 bool) bittorrent.Scrape
+	ScrapeSwarm(infoHash bittorrent.InfoHash, addressFamily bittorrent.AddressFamily) bittorrent.Scrape
 
 	// Stopper is an interface that expects a Stop method to stop the
 	// PeerStore.

--- a/storage/storage_bench.go
+++ b/storage/storage_bench.go
@@ -45,7 +45,7 @@ func generatePeers() (a [1000]bittorrent.Peer) {
 		port := uint16(r.Uint32())
 		a[i] = bittorrent.Peer{
 			ID:   bittorrent.PeerID(id),
-			IP:   net.IP(ip),
+			IP:   bittorrent.IP{IP: net.IP(ip), AddressFamily: bittorrent.IPv4},
 			Port: port,
 		}
 	}

--- a/storage/storage_tests.go
+++ b/storage/storage_tests.go
@@ -20,20 +20,20 @@ func TestPeerStore(t *testing.T, p PeerStore) {
 	}{
 		{
 			bittorrent.InfoHashFromString("00000000000000000001"),
-			bittorrent.Peer{ID: bittorrent.PeerIDFromString("00000000000000000001"), Port: 1, IP: net.ParseIP("1.1.1.1").To4()},
+			bittorrent.Peer{ID: bittorrent.PeerIDFromString("00000000000000000001"), Port: 1, IP: bittorrent.IP{IP: net.ParseIP("1.1.1.1").To4(), AddressFamily: bittorrent.IPv4}},
 		},
 		{
 			bittorrent.InfoHashFromString("00000000000000000002"),
-			bittorrent.Peer{ID: bittorrent.PeerIDFromString("00000000000000000002"), Port: 2, IP: net.ParseIP("abab::0001")},
+			bittorrent.Peer{ID: bittorrent.PeerIDFromString("00000000000000000002"), Port: 2, IP: bittorrent.IP{IP: net.ParseIP("abab::0001"), AddressFamily: bittorrent.IPv6}},
 		},
 	}
 
-	v4Peer := bittorrent.Peer{ID: bittorrent.PeerIDFromString("99999999999999999994"), IP: net.ParseIP("99.99.99.99").To4(), Port: 9994}
-	v6Peer := bittorrent.Peer{ID: bittorrent.PeerIDFromString("99999999999999999996"), IP: net.ParseIP("fc00::0001"), Port: 9996}
+	v4Peer := bittorrent.Peer{ID: bittorrent.PeerIDFromString("99999999999999999994"), IP: bittorrent.IP{IP: net.ParseIP("99.99.99.99").To4(), AddressFamily: bittorrent.IPv4}, Port: 9994}
+	v6Peer := bittorrent.Peer{ID: bittorrent.PeerIDFromString("99999999999999999996"), IP: bittorrent.IP{IP: net.ParseIP("fc00::0001"), AddressFamily: bittorrent.IPv6}, Port: 9996}
 
 	for _, c := range testData {
 		peer := v4Peer
-		if len(c.peer.IP) == net.IPv6len {
+		if c.peer.IP.AddressFamily == bittorrent.IPv6 {
 			peer = v6Peer
 		}
 
@@ -48,7 +48,7 @@ func TestPeerStore(t *testing.T, p PeerStore) {
 		require.Equal(t, ErrResourceDoesNotExist, err)
 
 		// Test empty scrape response for non-existent swarms.
-		scrape := p.ScrapeSwarm(c.ih, len(c.peer.IP) == net.IPv6len)
+		scrape := p.ScrapeSwarm(c.ih, c.peer.IP.AddressFamily)
 		require.Equal(t, uint32(0), scrape.Complete)
 		require.Equal(t, uint32(0), scrape.Incomplete)
 		require.Equal(t, uint32(0), scrape.Snatches)
@@ -76,7 +76,7 @@ func TestPeerStore(t *testing.T, p PeerStore) {
 		require.Nil(t, err)
 		require.True(t, containsPeer(peers, c.peer))
 
-		scrape = p.ScrapeSwarm(c.ih, len(c.peer.IP) == net.IPv6len)
+		scrape = p.ScrapeSwarm(c.ih, c.peer.IP.AddressFamily)
 		require.Equal(t, uint32(2), scrape.Incomplete)
 		require.Equal(t, uint32(0), scrape.Complete)
 
@@ -97,7 +97,7 @@ func TestPeerStore(t *testing.T, p PeerStore) {
 		require.Nil(t, err)
 		require.True(t, containsPeer(peers, c.peer))
 
-		scrape = p.ScrapeSwarm(c.ih, len(c.peer.IP) == net.IPv6len)
+		scrape = p.ScrapeSwarm(c.ih, c.peer.IP.AddressFamily)
 		require.Equal(t, uint32(1), scrape.Incomplete)
 		require.Equal(t, uint32(1), scrape.Complete)
 


### PR DESCRIPTION
This adds

1. Benchmarks for hooks. This helps estimate the overhead of our middleware-based approach and to make possible optimizations (i.e. reuse the `AnnounceResponse` struct).
2. An `AddressFamily` field for `Peer`s.
3. A hook that checks a Peer's IP and sets the above field, and also checks numWant.

Also, can a native speaker please tell me whether to name this `sanitationHook` `sanitizationHook` or something else entirely? That'd be great :)

This is about #254 mostly


Results of three benchmark runs on my laptop: (`none` has no middleware at all, just the `AnnounceResponse` alloc, _k_`nop` has _k_ no-op hooks chained, _k_`sanitation` has _k_ sanitation hooks chained)
```
name                         time/op
HookOverhead/none-v4         145ns ± 3%
HookOverhead/none-v6         146ns ± 1%
HookOverhead/1nop-v4         154ns ± 2%
HookOverhead/1nop-v6         155ns ± 0%
HookOverhead/2nop-v4         159ns ± 2%
HookOverhead/2nop-v6         157ns ± 1%
HookOverhead/3nop-v4         163ns ± 4%
HookOverhead/3nop-v6         166ns ± 4%
HookOverhead/1sanitation-v4  168ns ± 0%
HookOverhead/1sanitation-v6  164ns ± 0%
HookOverhead/2sanitation-v4  174ns ± 1%
HookOverhead/2sanitation-v6  180ns ± 2%
HookOverhead/3sanitation-v4  188ns ± 4%
HookOverhead/3sanitation-v6  196ns ± 1%
```
For whomever is interested: I attached the raw benchmark results as [bench.txt](https://github.com/chihaya/chihaya/files/617357/bench.txt).

The PR is WIP. In case we move forward with this:

- [x] Replace usages of `len(Peer.IP)`
- [x] Remove IP checks in the frontend
- [x] Remove `numWant` checks in the storage
- [x] (optional) Add a `defaultNumWant` config field