### PR TITLE
storage: added a redis storage option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# External packages folder
+vendor/
+
+#ctags/gotags
+tags
+
+#chihaya buildable
+chihaya

--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -12,12 +12,20 @@ import (
 	"github.com/chihaya/chihaya/middleware"
 	"github.com/chihaya/chihaya/middleware/clientapproval"
 	"github.com/chihaya/chihaya/middleware/jwt"
+	"github.com/chihaya/chihaya/storage"
 	"github.com/chihaya/chihaya/storage/memory"
+	"github.com/chihaya/chihaya/storage/redis"
 )
 
 type hookConfig struct {
 	Name   string      `yaml:"name"`
 	Config interface{} `yaml:"config"`
+}
+
+// Storage is a mapslice that lets me manipulate sub storage
+type Storage struct {
+	Type   string        `yaml:"type"`
+	Config yaml.MapSlice `yaml:"config"`
 }
 
 // ConfigFile represents a namespaced YAML configation file.
@@ -27,7 +35,7 @@ type ConfigFile struct {
 		PrometheusAddr    string              `yaml:"prometheus_addr"`
 		HTTPConfig        httpfrontend.Config `yaml:"http"`
 		UDPConfig         udpfrontend.Config  `yaml:"udp"`
-		Storage           memory.Config       `yaml:"storage"`
+		Storage           Storage             `yaml:"storage"`
 		PreHooks          []hookConfig        `yaml:"prehooks"`
 		PostHooks         []hookConfig        `yaml:"posthooks"`
 	} `yaml:"chihaya"`
@@ -60,6 +68,38 @@ func ParseConfigFile(path string) (*ConfigFile, error) {
 	}
 
 	return &cfgFile, nil
+}
+
+func (cfg ConfigFile) CreateStorage() (storage.PeerStore, error) {
+	storage, err := yaml.Marshal(&cfg.MainConfigBlock.Storage.Config)
+	if err != nil {
+		return nil, err
+	}
+	switch cfg.MainConfigBlock.Storage.Type {
+	case "memory":
+		var mem memory.Config
+		err := yaml.Unmarshal(storage, &mem)
+		if err != nil {
+			return nil, err
+		}
+		peerStore, err := memory.New(mem)
+		if err != nil {
+			return nil, err
+		}
+		return peerStore, nil
+	case "redis":
+		var red redis.Config
+		err := yaml.Unmarshal(storage, &red)
+		if err != nil {
+			return nil, err
+		}
+		peerStore, err := redis.New(red)
+		if err != nil {
+			return nil, err
+		}
+		return peerStore, nil
+	}
+	return nil, err
 }
 
 // CreateHooks creates instances of Hooks for all of the PreHooks and PostHooks

--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/RealImage/chihaya/storage/redis"
 	httpfrontend "github.com/chihaya/chihaya/frontend/http"
 	udpfrontend "github.com/chihaya/chihaya/frontend/udp"
 	"github.com/chihaya/chihaya/middleware"
@@ -14,7 +15,6 @@ import (
 	"github.com/chihaya/chihaya/middleware/jwt"
 	"github.com/chihaya/chihaya/storage"
 	"github.com/chihaya/chihaya/storage/memory"
-	"github.com/chihaya/chihaya/storage/redis"
 )
 
 type hookConfig struct {

--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -70,6 +70,7 @@ func ParseConfigFile(path string) (*ConfigFile, error) {
 	return &cfgFile, nil
 }
 
+// CreateStorage returns a peerStore instance based on the yaml file
 func (cfg ConfigFile) CreateStorage() (storage.PeerStore, error) {
 	storage, err := yaml.Marshal(&cfg.MainConfigBlock.Storage.Config)
 	if err != nil {

--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -7,7 +7,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/RealImage/chihaya/storage/redis"
 	httpfrontend "github.com/chihaya/chihaya/frontend/http"
 	udpfrontend "github.com/chihaya/chihaya/frontend/udp"
 	"github.com/chihaya/chihaya/middleware"
@@ -15,6 +14,7 @@ import (
 	"github.com/chihaya/chihaya/middleware/jwt"
 	"github.com/chihaya/chihaya/storage"
 	"github.com/chihaya/chihaya/storage/memory"
+	"github.com/chihaya/chihaya/storage/redis"
 )
 
 type hookConfig struct {

--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -22,10 +22,9 @@ type hookConfig struct {
 	Config interface{} `yaml:"config"`
 }
 
-// Storage is a mapslice that lets me manipulate sub storage
-type Storage struct {
-	Type   string        `yaml:"type"`
-	Config yaml.MapSlice `yaml:"config"`
+type store struct {
+	Type   string      `yaml:"type"`
+	Config interface{} `yaml:"config"`
 }
 
 // ConfigFile represents a namespaced YAML configation file.
@@ -35,7 +34,7 @@ type ConfigFile struct {
 		PrometheusAddr    string              `yaml:"prometheus_addr"`
 		HTTPConfig        httpfrontend.Config `yaml:"http"`
 		UDPConfig         udpfrontend.Config  `yaml:"udp"`
-		Storage           Storage             `yaml:"storage"`
+		Storage           store               `yaml:"storage"`
 		PreHooks          []hookConfig        `yaml:"prehooks"`
 		PostHooks         []hookConfig        `yaml:"posthooks"`
 	} `yaml:"chihaya"`

--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -16,7 +16,6 @@ import (
 	udpfrontend "github.com/chihaya/chihaya/frontend/udp"
 	"github.com/chihaya/chihaya/middleware"
 	"github.com/chihaya/chihaya/storage"
-	"github.com/chihaya/chihaya/storage/memory"
 )
 
 func rootCmdRun(cmd *cobra.Command, args []string) error {
@@ -54,9 +53,9 @@ func rootCmdRun(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	peerStore, err := memory.New(cfg.Storage)
+	peerStore, err := configFile.CreateStorage()
 	if err != nil {
-		return errors.New("failed to create memory storage: " + err.Error())
+		return errors.New("failed to create storage: " + err.Error())
 	}
 
 	preHooks, postHooks, err := configFile.CreateHooks()

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -18,10 +18,22 @@ chihaya:
       paste a random string here that will be used to hmac connection IDs
 
   storage:
-    gc_interval: 14m
-    peer_lifetime: 15m
-    shards: 1
-    max_numwant: 100
+    #comment out one of these types to choose storage type
+    type: memory
+    config:
+      gc_interval: 14m
+      peer_lifetime: 15m
+      shards: 1
+      max_numwant: 100
+      #    type: redis 
+      #    config:
+      #      key_prefix: nm 
+      #      instance: 0
+      #      max_numwant: 100
+      #      host: 127.0.0.1
+      #      port: 6379
+      #      gc_interval: 15m 
+      #      peer_liftetime: 15m
 
   prehooks:
   - name: jwt

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -25,15 +25,15 @@ chihaya:
       peer_lifetime: 15m
       shards: 1
       max_numwant: 100
-      #    type: redis 
-      #    config:
-      #      key_prefix: "nm:"
-      #      instance: 0
-      #      max_numwant: 100
-      #      host: 127.0.0.1
-      #      port: 6379
-      #      gc_interval: 15m 
-      #      peer_liftetime: 15m
+#   type: redis 
+#   config:
+#     key_prefix: "nm:"
+#     instance: 0
+#     max_numwant: 100
+#     host: 127.0.0.1
+#     port: 6379
+#     gc_interval: 15m 
+#     peer_liftetime: 15m
 
   prehooks:
   - name: jwt

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -30,6 +30,7 @@ chihaya:
 #     key_prefix: "nm:"
 #     instance: 0
 #     max_numwant: 100
+#     max_idle: 100
 #     host: 127.0.0.1
 #     port: 6379
 #     gc_interval: 15m 

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,17 @@
 hash: fe839da75efcf365317b1b5eb04bfa15cd1db10265f4947b8aff78932bf4622e
-updated: 2016-09-05T18:13:39.020799284-04:00
+updated: 2016-12-23T12:35:09.584009444+05:30
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/garyburd/redigo
+  version: f8c71fc158ba13d50a7f5d8f10ea18ec49463c73
+  subpackages:
+  - internal
+  - redis
 - name: github.com/golang/protobuf
-  version: 1f49d83d9aa00e6ce4fc8258c71cc7786aec968a
+  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
   - proto
 - name: github.com/inconshreveable/mousetrap
@@ -28,13 +33,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 616e90af75cc300730196d04f3676f838d70414f
+  version: 6d76b79f239843a04e8ad8dfd8fcadfa3920236f
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
+  version: fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60
 - name: github.com/SermoDigital/jose
   version: 389fea327ef076853db8fae03a0f38e30e6092ab
   subpackages:
@@ -44,27 +49,29 @@ imports:
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: github.com/spf13/cobra
-  version: 9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744
+  version: de09d9ce07d0d8a74442cfeaa91628cf9492cc23
 - name: github.com/spf13/pflag
-  version: 103ce5cd2042f2fe629c1957abb64ab3e7f50235
+  version: 25f8b5b07aece3207895bf19f7ab517eb3b22a40
 - name: github.com/tylerb/graceful
   version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/rafaeljusto/redigomock
+  version: 8a39246926d9f2a732f775c5b360d7078191cbbd
 - name: github.com/stretchr/testify
-  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/chihaya/chihaya
 import:
+- package: github.com/garyburd/redigo
+- package: github.com/rafaeljusto/redigomock
 - package: github.com/SermoDigital/jose
   version: ~1.0.0
   subpackages:

--- a/storage/redis/peer_crud.go
+++ b/storage/redis/peer_crud.go
@@ -1,0 +1,79 @@
+package redis
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/chihaya/chihaya/bittorrent"
+	redigo "github.com/garyburd/redigo/redis"
+)
+
+func decodePeerKey(pk string) bittorrent.Peer {
+	return bittorrent.Peer{
+		ID:   bittorrent.PeerIDFromString(string(pk[:20])),
+		Port: binary.BigEndian.Uint16([]byte(pk[20:22])),
+		IP:   net.IP(pk[22:]),
+	}
+}
+
+//Adds an expiry to the set if not refreshed
+func addPeer(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
+	pk serializedPeer) error {
+	Key := fmt.Sprintf("%s%s", peerType+":", infoHash)
+	s.conn.Send("MULTI")
+	s.conn.Send("ZADD", Key, time.Now().Unix(), pk)
+	s.conn.Send("EXPIRE", Key, int(s.peerLifetime.Seconds()))
+	_, err := s.conn.Do("EXEC")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func removePeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
+	pk serializedPeer) error {
+	_, err := s.conn.Do("ZREM",
+		fmt.Sprintf("%s%s", peerType+":", infoHash), pk)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Prunes the existing infohash swarm for any old peers before
+// returning range of valid peers
+func getPeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
+	numWant int, peers []bittorrent.Peer, excludePeers bittorrent.Peer) (
+	[]bittorrent.Peer, error) {
+	Key := fmt.Sprintf("%s%s", peerType+":", infoHash)
+	_, err := s.conn.Do("ZREMRANGEBYSCORE", Key,
+		"-inf",
+		fmt.Sprintf("%s%d", "(", time.Now().Add(-s.peerLifetime).Unix()))
+	if err != nil {
+		return nil, err
+	}
+	peerList, err := redigo.Strings(s.conn.Do("ZRANGE",
+		Key, 0, -1))
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range peerList {
+		if numWant == len(peers) {
+			break
+		}
+		decodedPeer := decodePeerKey(p)
+		if decodedPeer.Equal(excludePeers) {
+			continue
+		}
+		peers = append(peers, decodedPeer)
+	}
+	return peers, nil
+}
+
+func getPeersLength(s *peerStore, infoHash bittorrent.InfoHash,
+	peerType string) (int, error) {
+	return redigo.Int(s.conn.Do("ZCARD",
+		fmt.Sprintf("%s%s", peerType+":", infoHash)))
+}

--- a/storage/redis/peer_crud.go
+++ b/storage/redis/peer_crud.go
@@ -6,8 +6,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/chihaya/chihaya/bittorrent"
 	redigo "github.com/garyburd/redigo/redis"
+
+	"github.com/chihaya/chihaya/bittorrent"
 )
 
 func decodePeerKey(pk string) bittorrent.Peer {
@@ -18,10 +19,9 @@ func decodePeerKey(pk string) bittorrent.Peer {
 	}
 }
 
-//Adds an expiry to the set if not refreshed
-func addPeer(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
-	pk serializedPeer) error {
-	Key := fmt.Sprintf("%s%s", peerType+":", infoHash)
+//Adds an expiry to the set, that self deletes if not refreshed
+func addPeer(s *peerStore, infoHash bittorrent.InfoHash, peerType string, pk serializedPeer) error {
+	Key := fmt.Sprintf("%s:%s", peerType, infoHash)
 	s.conn.Send("MULTI")
 	s.conn.Send("ZADD", Key, time.Now().Unix(), pk)
 	s.conn.Send("EXPIRE", Key, int(s.peerLifetime.Seconds()))
@@ -32,10 +32,8 @@ func addPeer(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
 	return nil
 }
 
-func removePeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
-	pk serializedPeer) error {
-	_, err := s.conn.Do("ZREM",
-		fmt.Sprintf("%s%s", peerType+":", infoHash), pk)
+func removePeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string, pk serializedPeer) error {
+	_, err := s.conn.Do("ZREM", fmt.Sprintf("%s:%s", peerType, infoHash), pk)
 	if err != nil {
 		return err
 	}
@@ -44,18 +42,13 @@ func removePeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
 
 // Prunes the existing infohash swarm for any old peers before
 // returning range of valid peers
-func getPeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
-	numWant int, peers []bittorrent.Peer, excludePeers bittorrent.Peer) (
-	[]bittorrent.Peer, error) {
-	Key := fmt.Sprintf("%s%s", peerType+":", infoHash)
-	_, err := s.conn.Do("ZREMRANGEBYSCORE", Key,
-		"-inf",
-		fmt.Sprintf("%s%d", "(", time.Now().Add(-s.peerLifetime).Unix()))
+func getPeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string, numWant int, peers []bittorrent.Peer, excludePeers bittorrent.Peer) ([]bittorrent.Peer, error) {
+	Key := fmt.Sprintf("%s:%s", peerType, infoHash)
+	_, err := s.conn.Do("ZREMRANGEBYSCORE", Key, "-inf", fmt.Sprintf("(%d", time.Now().Add(-s.peerLifetime).Unix()))
 	if err != nil {
 		return nil, err
 	}
-	peerList, err := redigo.Strings(s.conn.Do("ZRANGE",
-		Key, 0, -1))
+	peerList, err := redigo.Strings(s.conn.Do("ZRANGE", Key, 0, -1))
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +65,6 @@ func getPeers(s *peerStore, infoHash bittorrent.InfoHash, peerType string,
 	return peers, nil
 }
 
-func getPeersLength(s *peerStore, infoHash bittorrent.InfoHash,
-	peerType string) (int, error) {
-	return redigo.Int(s.conn.Do("ZCARD",
-		fmt.Sprintf("%s%s", peerType+":", infoHash)))
+func getPeersLength(s *peerStore, infoHash bittorrent.InfoHash, peerType string) (int, error) {
+	return redigo.Int(s.conn.Do("ZCARD", fmt.Sprintf("%s:%s", peerType, infoHash)))
 }

--- a/storage/redis/peer_crud_test.go
+++ b/storage/redis/peer_crud_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chihaya/chihaya/bittorrent"
 	"github.com/rafaeljusto/redigomock"
+
+	"github.com/chihaya/chihaya/bittorrent"
 )
 
 var testPeers = []struct {

--- a/storage/redis/peer_crud_test.go
+++ b/storage/redis/peer_crud_test.go
@@ -1,0 +1,145 @@
+package redis
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/chihaya/chihaya/bittorrent"
+	"github.com/rafaeljusto/redigomock"
+)
+
+var testPeers = []struct {
+	vals      bittorrent.Peer
+	ih        bittorrent.InfoHash
+	numPeers  int
+	peers     []bittorrent.Peer
+	announcer bittorrent.Peer
+	expected  error
+	rangeVals []interface{}
+	expectedL int64
+}{
+	{bittorrent.Peer{
+		ID:   bittorrent.PeerIDFromString("12345678912345678912"),
+		IP:   net.IP("112.71.10.240"),
+		Port: 7002},
+		bittorrent.InfoHashFromString("12345678912345678912"), 0,
+		[]bittorrent.Peer{},
+		bittorrent.Peer{}, nil,
+		[]interface{}{[]byte("12345678912345678912"),
+			[]byte("abcdefgixxxxxxxxxxxxxxx"),
+			[]byte("12354634ir78an0ob7151"),
+			[]byte("000000000000000000000")},
+		5,
+	},
+	{bittorrent.Peer{
+		ID:   bittorrent.PeerIDFromString("#!@#$%^$*()&*#$*~al:"),
+		IP:   net.IP("10:71:10:1A:2B"),
+		Port: 1111},
+		bittorrent.InfoHashFromString("4:test3i:123:er123rt"), 1,
+		[]bittorrent.Peer{bittorrent.Peer{
+			ID:   bittorrent.PeerIDFromString("totallydifferent1234"),
+			IP:   net.IP("XX:71:10:1A:2X"),
+			Port: 1234}},
+		bittorrent.Peer{},
+		nil,
+		[]interface{}{[]byte("")},
+		2,
+	}, {bittorrent.Peer{
+		ID:   bittorrent.PeerIDFromString("////////////////////"),
+		IP:   net.IP("192.168.0.2"),
+		Port: 12356},
+		bittorrent.InfoHashFromString("////////////////////"), 0,
+		[]bittorrent.Peer{},
+		bittorrent.Peer{}, nil,
+		[]interface{}{[]byte("")},
+		1,
+	},
+}
+
+func getPeerStore() (*redigomock.Conn, *peerStore) {
+	conn := redigomock.NewConn()
+	return conn, &peerStore{
+		conn:         conn,
+		closed:       make(chan struct{}),
+		maxNumWant:   3,
+		peerLifetime: 15,
+		gcValidity:   1500000,
+	}
+}
+
+func TestAddPeer(t *testing.T) {
+	conn, ps := getPeerStore()
+	for _, tp := range testPeers {
+		peer := fmt.Sprintf("%s%s", "seeder:", tp.ih)
+		pk := newPeerKey(tp.vals)
+		conn.Command("MULTI").Expect("OK")
+		conn.Command("ZADD", peer, time.Now().Unix(), pk).Expect("QUEUED")
+		conn.Command("EXPIRE", peer, int(ps.peerLifetime.Seconds())).
+			Expect("QUEUED")
+		conn.Command("EXEC").Expect("1) OK\n2) OK")
+		err := addPeer(ps, tp.ih, "seeder", pk)
+		if err != tp.expected {
+			t.Error("addPeer redis fail : ", err)
+		}
+	}
+}
+
+func TestRemPeers(t *testing.T) {
+	conn, ps := getPeerStore()
+	conn.Clear()
+	for _, tp := range testPeers {
+		peer := fmt.Sprintf("%s%s", "seeder:", tp.ih)
+		pk := newPeerKey(tp.vals)
+		conn.Command("ZREM", peer, pk).Expect("(integer) 1")
+		err := removePeers(ps, tp.ih, "seeder", pk)
+		if err != tp.expected {
+			t.Error("remPeers redis fail:", err)
+		}
+	}
+}
+
+func TestGetPeers(t *testing.T) {
+	conn, ps := getPeerStore()
+	conn.Clear()
+	for _, tp := range testPeers {
+		peer := fmt.Sprintf("%s%s", "leecher:", tp.ih)
+		conn.Command("ZREMRANGEBYSCORE", peer, "-inf",
+			fmt.Sprintf("%s%d", "(", time.Now().Add(-ps.peerLifetime).Unix())).
+			Expect("(integer 1)")
+		conn.Command("ZRANGE", peer, 0, -1).Expect(tp.rangeVals)
+		peers, err := getPeers(ps, tp.ih, "leecher",
+			tp.numPeers, tp.peers, tp.announcer)
+		if err != nil {
+			t.Error("getPeers redis fail:", err)
+		} else {
+			if len(peers) != tp.numPeers {
+				t.Error("getPeers logic fail : peer length issue")
+			}
+			for _, peerling := range peers {
+				if peerling.ID == tp.announcer.ID {
+					t.Error("getPeers logic fail : announcer not ignored")
+				}
+			}
+		}
+	}
+}
+
+func TestGetSetLength(t *testing.T) {
+	conn, ps := getPeerStore()
+	conn.Clear()
+	for _, tp := range testPeers {
+		peer := fmt.Sprintf("%s%s", "leecher:", tp.ih)
+		conn.Command("ZCARD", peer).Expect(tp.expectedL)
+		Actlen, err := getPeersLength(ps, tp.ih, "leecher")
+		if err != nil {
+			t.Error("getSEtLength redis fail: ", err)
+		} else {
+			if int64(Actlen) != tp.expectedL {
+				t.Error("getSetLength logic fail: length mismatch")
+			}
+
+		}
+	}
+}

--- a/storage/redis/peer_store.go
+++ b/storage/redis/peer_store.go
@@ -1,4 +1,3 @@
-// Note: ip6 separation into shards is unnecessary when using Redis
 package redis
 
 import (

--- a/storage/redis/peer_store.go
+++ b/storage/redis/peer_store.go
@@ -85,9 +85,8 @@ func panicIfClosed(closed <-chan struct{}) {
 func ipType(ip net.IP) string {
 	if len(ip) == net.IPv6len {
 		return ipv6
-	} else {
-		return ipv4
 	}
+	return ipv4
 }
 
 func (s *peerStore) PutSeeder(infoHash bittorrent.InfoHash,

--- a/storage/redis/peer_store.go
+++ b/storage/redis/peer_store.go
@@ -6,9 +6,10 @@ import (
 	"net"
 	"time"
 
+	redigo "github.com/garyburd/redigo/redis"
+
 	"github.com/chihaya/chihaya/bittorrent"
 	"github.com/chihaya/chihaya/storage"
-	redigo "github.com/garyburd/redigo/redis"
 )
 
 const (
@@ -18,8 +19,8 @@ const (
 
 // Config holds the configuration of a redis peerstore.
 // KeyPrefix specifies the prefix that could optionally precede keys
-// Instance specifies the redis database number to connect to(default 0)
-// max_numwant is the maximum number of peers to return to announce
+// Instance specifies the redis database number to connect to (default 0)
+// MaxNumWant is the maximum number of peers to return to announce
 type Config struct {
 	KeyPrefix    string        `yaml:"key_prefix"`
 	Instance     int           `yaml:"instance"`
@@ -39,11 +40,11 @@ type peerStore struct {
 	leecherKeyPrefix string
 }
 
-//New creates a new peerstore backed by redis
+// New creates a new peerstore backed by redis.
 func New(cfg Config) (storage.PeerStore, error) {
 	conn, err := redigo.Dial("tcp", cfg.Host+":"+cfg.Port)
 	if err != nil {
-		log.Fatal("Connection failed:" + err.Error())
+		log.Fatal("Connection failed: " + err.Error())
 		return nil, err
 	}
 
@@ -89,39 +90,32 @@ func ipType(ip net.IP) string {
 	return ipv4
 }
 
-func (s *peerStore) PutSeeder(infoHash bittorrent.InfoHash,
-	p bittorrent.Peer) error {
+func (s *peerStore) PutSeeder(infoHash bittorrent.InfoHash, p bittorrent.Peer) error {
 	panicIfClosed(s.closed)
 
 	pk := newPeerKey(p)
 	return addPeer(s, infoHash, s.seederKeyPrefix+ipType(p.IP), pk)
 }
 
-func (s *peerStore) DeleteSeeder(infoHash bittorrent.InfoHash,
-	p bittorrent.Peer) error {
+func (s *peerStore) DeleteSeeder(infoHash bittorrent.InfoHash, p bittorrent.Peer) error {
 	panicIfClosed(s.closed)
 	pk := newPeerKey(p)
 	return removePeers(s, infoHash, s.seederKeyPrefix+ipType(p.IP), pk)
 }
 
-func (s *peerStore) PutLeecher(infoHash bittorrent.InfoHash,
-	p bittorrent.Peer) error {
+func (s *peerStore) PutLeecher(infoHash bittorrent.InfoHash, p bittorrent.Peer) error {
 	panicIfClosed(s.closed)
 	pk := newPeerKey(p)
 	return addPeer(s, infoHash, s.leecherKeyPrefix+ipType(p.IP), pk)
-
 }
 
-func (s *peerStore) DeleteLeecher(infoHash bittorrent.InfoHash,
-	p bittorrent.Peer) error {
+func (s *peerStore) DeleteLeecher(infoHash bittorrent.InfoHash, p bittorrent.Peer) error {
 	panicIfClosed(s.closed)
 	pk := newPeerKey(p)
 	return removePeers(s, infoHash, s.leecherKeyPrefix+ipType(p.IP), pk)
-
 }
 
-func (s *peerStore) GraduateLeecher(infoHash bittorrent.InfoHash,
-	p bittorrent.Peer) error {
+func (s *peerStore) GraduateLeecher(infoHash bittorrent.InfoHash, p bittorrent.Peer) error {
 	panicIfClosed(s.closed)
 	err := s.PutSeeder(infoHash, p)
 	if err != nil {
@@ -136,54 +130,42 @@ func (s *peerStore) GraduateLeecher(infoHash bittorrent.InfoHash,
 
 // Announce as many peers as possible based on the announcer being
 // a seeder or leecher
-func (s *peerStore) AnnouncePeers(infoHash bittorrent.InfoHash, seeder bool,
-	numWant int, announcer bittorrent.Peer) (peers []bittorrent.Peer,
-	err error) {
+func (s *peerStore) AnnouncePeers(infoHash bittorrent.InfoHash, seeder bool, numWant int, announcer bittorrent.Peer) (peers []bittorrent.Peer, err error) {
 	panicIfClosed(s.closed)
 	if numWant > s.maxNumWant {
 		numWant = s.maxNumWant
 	}
 
-	peers = []bittorrent.Peer{}
 	if seeder {
-		peers, err = getPeers(s, infoHash,
-			s.leecherKeyPrefix+ipType(announcer.IP),
-			numWant, peers, bittorrent.Peer{})
+		peers, err = getPeers(s, infoHash, s.leecherKeyPrefix+ipType(announcer.IP), numWant, peers, bittorrent.Peer{})
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		peers, err = getPeers(s, infoHash,
-			s.seederKeyPrefix+ipType(announcer.IP),
-			numWant, peers, bittorrent.Peer{})
+		peers, err = getPeers(s, infoHash, s.seederKeyPrefix+ipType(announcer.IP), numWant, peers, bittorrent.Peer{})
 		if err != nil {
 			return nil, err
 		}
 		if len(peers) < numWant {
-			peers, err = getPeers(s, infoHash,
-				s.leecherKeyPrefix+ipType(announcer.IP),
-				numWant, peers, announcer)
+			peers, err = getPeers(s, infoHash, s.leecherKeyPrefix+ipType(announcer.IP), numWant, peers, announcer)
 		}
 	}
 	return peers, nil
 }
 
-func (s *peerStore) ScrapeSwarm(infoHash bittorrent.InfoHash, v6 bool) (
-	resp bittorrent.Scrape) {
+func (s *peerStore) ScrapeSwarm(infoHash bittorrent.InfoHash, v6 bool) (resp bittorrent.Scrape) {
 	panicIfClosed(s.closed)
 
 	ipType := ipv4
 	if v6 {
 		ipType = ipv6
 	}
-	complete, err := getPeersLength(s, infoHash,
-		s.seederKeyPrefix+ipType)
+	complete, err := getPeersLength(s, infoHash, s.seederKeyPrefix+ipType)
 	if err != nil {
 		return
 	}
 	resp.Complete = uint32(complete)
-	incomplete, err := getPeersLength(s, infoHash,
-		s.leecherKeyPrefix+ipType)
+	incomplete, err := getPeersLength(s, infoHash, s.leecherKeyPrefix+ipType)
 	if err != nil {
 		return
 	}
@@ -193,8 +175,10 @@ func (s *peerStore) ScrapeSwarm(infoHash bittorrent.InfoHash, v6 bool) (
 
 func (s *peerStore) Stop() <-chan error {
 	toReturn := make(chan error)
-	close(s.closed)
-	s.conn.Close()
-	close(toReturn)
+	go func() {
+		close(s.closed)
+		s.conn.Close()
+		close(toReturn)
+	}()
 	return toReturn
 }

--- a/storage/redis/peer_store.go
+++ b/storage/redis/peer_store.go
@@ -1,0 +1,185 @@
+// Note: ip6 separation into shards is unnecessary when using Redis
+package redis
+
+import (
+	"encoding/binary"
+	"log"
+	"time"
+
+	"github.com/chihaya/chihaya/bittorrent"
+	"github.com/chihaya/chihaya/storage"
+	redigo "github.com/garyburd/redigo/redis"
+)
+
+// Config holds the configuration of a redis peerstore.
+// KeyPrefix specifies the prefix that could optionally precede keys
+// Instance specifies the redis database number to connect to(default 0)
+// max_numwant is the maximum number of peers to return to announce
+type Config struct {
+	KeyPrefix    string        `yaml:"key_prefix"`
+	Instance     int           `yaml:"instance"`
+	MaxNumWant   int           `yaml:"max_numwant"`
+	Host         string        `yaml:"host"`
+	Port         string        `yaml:"port"`
+	PeerLifetime time.Duration `yaml:"peer_liftetime"`
+}
+
+type peerStore struct {
+	conn             redigo.Conn
+	closed           chan struct{}
+	maxNumWant       int
+	peerLifetime     time.Duration
+	gcValidity       int
+	seederKeyPrefix  string
+	leecherKeyPrefix string
+}
+
+//New creates a new peerstore backed by redis
+func New(cfg Config) (storage.PeerStore, error) {
+	conn, err := redigo.Dial("tcp", cfg.Host+":"+cfg.Port)
+	if err != nil {
+		log.Fatal("Connection failed:" + err.Error())
+		return nil, err
+	}
+
+	if cfg.Instance != 0 {
+		conn.Do("SELECT", cfg.Instance)
+	}
+
+	ps := &peerStore{
+		conn:             conn,
+		closed:           make(chan struct{}),
+		maxNumWant:       cfg.MaxNumWant,
+		peerLifetime:     cfg.PeerLifetime,
+		seederKeyPrefix:  addKeyPrefix(cfg.KeyPrefix, "seeder"),
+		leecherKeyPrefix: addKeyPrefix(cfg.KeyPrefix, "leecher"),
+	}
+
+	return ps, nil
+}
+
+type serializedPeer string
+
+func newPeerKey(p bittorrent.Peer) serializedPeer {
+	b := make([]byte, 20+2+len(p.IP))
+	copy(b[:20], p.ID[:])
+	binary.BigEndian.PutUint16(b[20:22], p.Port)
+	copy(b[22:], p.IP)
+
+	return serializedPeer(b)
+}
+
+func panicIfClosed(closed <-chan struct{}) {
+	select {
+	case <-closed:
+		panic("attempted to interact with stopped redis store")
+	default:
+	}
+}
+
+func addKeyPrefix(namespacePrefix string, command string) string {
+	if namespacePrefix != "" {
+		return namespacePrefix + ":" + command
+	}
+	return command
+}
+
+func (s *peerStore) PutSeeder(infoHash bittorrent.InfoHash,
+	p bittorrent.Peer) error {
+	panicIfClosed(s.closed)
+
+	pk := newPeerKey(p)
+	return addPeer(s, infoHash, s.seederKeyPrefix, pk)
+}
+
+func (s *peerStore) DeleteSeeder(infoHash bittorrent.InfoHash,
+	p bittorrent.Peer) error {
+	panicIfClosed(s.closed)
+	pk := newPeerKey(p)
+	return removePeers(s, infoHash, s.seederKeyPrefix, pk)
+}
+
+func (s *peerStore) PutLeecher(infoHash bittorrent.InfoHash,
+	p bittorrent.Peer) error {
+	panicIfClosed(s.closed)
+	pk := newPeerKey(p)
+	return addPeer(s, infoHash, s.leecherKeyPrefix, pk)
+
+}
+
+func (s *peerStore) DeleteLeecher(infoHash bittorrent.InfoHash,
+	p bittorrent.Peer) error {
+	panicIfClosed(s.closed)
+	pk := newPeerKey(p)
+	return removePeers(s, infoHash, s.leecherKeyPrefix, pk)
+
+}
+
+func (s *peerStore) GraduateLeecher(infoHash bittorrent.InfoHash,
+	p bittorrent.Peer) error {
+	panicIfClosed(s.closed)
+	err := s.PutSeeder(infoHash, p)
+	if err != nil {
+		return err
+	}
+	err = s.DeleteLeecher(infoHash, p)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Announce as many peers as possible based on the announcer being
+// a seeder or leecher
+func (s *peerStore) AnnouncePeers(infoHash bittorrent.InfoHash, seeder bool,
+	numWant int, announcer bittorrent.Peer) (peers []bittorrent.Peer,
+	err error) {
+	panicIfClosed(s.closed)
+	if numWant > s.maxNumWant {
+		numWant = s.maxNumWant
+	}
+
+	peers = []bittorrent.Peer{}
+	if seeder {
+		peers, err = getPeers(s, infoHash, s.leecherKeyPrefix,
+			numWant, peers, bittorrent.Peer{})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		peers, err = getPeers(s, infoHash, s.seederKeyPrefix,
+			numWant, peers, bittorrent.Peer{})
+		if err != nil {
+			return nil, err
+		}
+		if len(peers) < numWant {
+			peers, err = getPeers(s, infoHash, s.leecherKeyPrefix,
+				numWant, peers, announcer)
+		}
+	}
+	return peers, nil
+}
+
+func (s *peerStore) ScrapeSwarm(infoHash bittorrent.InfoHash, v6 bool) (
+	resp bittorrent.Scrape) {
+	panicIfClosed(s.closed)
+	complete, err := getPeersLength(s, infoHash, s.seederKeyPrefix)
+	if err != nil {
+		return
+	}
+	resp.Complete = uint32(complete)
+	incomplete, err := getPeersLength(s, infoHash, s.leecherKeyPrefix)
+	if err != nil {
+		return
+	}
+	resp.Incomplete = uint32(incomplete)
+	return
+}
+
+func (s *peerStore) Stop() <-chan error {
+	toReturn := make(chan error)
+	close(s.closed)
+	s.conn.Close()
+	close(toReturn)
+	return toReturn
+}


### PR DESCRIPTION
## What this PR does
Adds a redis storage functionality

## Dependencies
github.com/garyburd/redigo
github.com/rafaelgusto/redigomock

## Additional details

1. Added a redistore method as an alternate storage option
     -   Each swarm is stored as a separate sorted set with time as a score as a combination of peertype and infohash. 
     -   Garbage collection is handled via redis EXPIRE and outdated peers(peers exceeding lifetime) are pruned during announce(AnnouncePeers).
      -   GraduateLeecher is a combination of PutSeeder and DeleteLeecher.


2. Modified config and yaml format a bit to pick up storage based on definition.
     -  Added a getStorage method to config.go to pick up config dynamically based on yaml
     -  example_config.yaml now has a minor identation change and a new field(type) indicating type of storage as well as new configurable values for redis.