### PR TITLE
udp: fix ordering of scrapes

### DIFF
--- a/bittorrent/bittorrent.go
+++ b/bittorrent/bittorrent.go
@@ -100,12 +100,16 @@ type ScrapeRequest struct {
 }
 
 // ScrapeResponse represents the parameters used to create a scrape response.
+//
+// The Scrapes must be in the same order as the InfoHashes in the corresponding
+// ScrapeRequest.
 type ScrapeResponse struct {
-	Files map[InfoHash]Scrape
+	Files []Scrape
 }
 
 // Scrape represents the state of a swarm that is returned in a scrape response.
 type Scrape struct {
+	InfoHash   InfoHash
 	Snatches   uint32
 	Complete   uint32
 	Incomplete uint32

--- a/frontend/http/writer.go
+++ b/frontend/http/writer.go
@@ -74,8 +74,8 @@ func WriteAnnounceResponse(w http.ResponseWriter, resp *bittorrent.AnnounceRespo
 // client over HTTP.
 func WriteScrapeResponse(w http.ResponseWriter, resp *bittorrent.ScrapeResponse) error {
 	filesDict := bencode.NewDict()
-	for infohash, scrape := range resp.Files {
-		filesDict[string(infohash[:])] = bencode.Dict{
+	for _, scrape := range resp.Files {
+		filesDict[string(scrape.InfoHash[:])] = bencode.Dict{
 			"complete":   scrape.Complete,
 			"incomplete": scrape.Incomplete,
 		}

--- a/middleware/hooks.go
+++ b/middleware/hooks.go
@@ -183,7 +183,7 @@ func (h *responseHook) HandleScrape(ctx context.Context, req *bittorrent.ScrapeR
 	}
 
 	for _, infoHash := range req.InfoHashes {
-		resp.Files[infoHash] = h.store.ScrapeSwarm(infoHash, req.AddressFamily)
+		resp.Files = append(resp.Files, h.store.ScrapeSwarm(infoHash, req.AddressFamily))
 	}
 
 	return ctx, nil

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -78,7 +78,7 @@ func (l *Logic) AfterAnnounce(ctx context.Context, req *bittorrent.AnnounceReque
 // HandleScrape generates a response for a Scrape.
 func (l *Logic) HandleScrape(ctx context.Context, req *bittorrent.ScrapeRequest) (resp *bittorrent.ScrapeResponse, err error) {
 	resp = &bittorrent.ScrapeResponse{
-		Files: make(map[bittorrent.InfoHash]bittorrent.Scrape),
+		Files: make([]bittorrent.Scrape, 0, len(req.InfoHashes)),
 	}
 	for _, h := range l.preHooks {
 		if ctx, err = h.HandleScrape(ctx, req, resp); err != nil {

--- a/storage/memory/peer_store.go
+++ b/storage/memory/peer_store.go
@@ -361,6 +361,7 @@ func (s *peerStore) ScrapeSwarm(ih bittorrent.InfoHash, addressFamily bittorrent
 	default:
 	}
 
+	resp.InfoHash = ih
 	shard := s.shards[s.shardIndex(ih, addressFamily)]
 	shard.RLock()
 


### PR DESCRIPTION
Fixes #280.

Or maybe we should change the `ScrapeResponse` to contain a slice of `Scrape`s and make them contain an `InfoHash`?