### PR TITLE
contrib/helm: default to using HEAD container

### DIFF
--- a/contrib/helm/chihaya/values.yaml
+++ b/contrib/helm/chihaya/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
-  repository: quay.io/jzelinskie/chihaya
-  tag: v2.0.0-rc.1
+  repository: quay.io/jzelinskie/chihaya-git
+  tag: latest
   pullPolicy: IfNotPresent
 service:
   name: chihaya


### PR DESCRIPTION
This fixes a bug where the config being used is for HEAD, but previously the container image being used was for a tagged release with a different config schema.