### PR TITLE
frontend: fix recording of address family

### DIFF
--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -166,6 +166,7 @@ func (t *Frontend) announceRoute(w http.ResponseWriter, r *http.Request, _ httpr
 		WriteError(w, err)
 		return
 	}
+	af = new(bittorrent.AddressFamily)
 	*af = req.IP.AddressFamily
 
 	resp, err := t.logic.HandleAnnounce(context.Background(), req)
@@ -213,6 +214,7 @@ func (t *Frontend) scrapeRoute(w http.ResponseWriter, r *http.Request, _ httprou
 		WriteError(w, ErrInvalidIP)
 		return
 	}
+	af = new(bittorrent.AddressFamily)
 	*af = req.AddressFamily
 
 	resp, err := t.logic.HandleScrape(context.Background(), req)

--- a/frontend/udp/frontend.go
+++ b/frontend/udp/frontend.go
@@ -232,6 +232,7 @@ func (t *Frontend) handleRequest(r Request, w ResponseWriter) (actionName string
 			WriteError(w, txID, err)
 			return
 		}
+		af = new(bittorrent.AddressFamily)
 		*af = req.IP.AddressFamily
 
 		var resp *bittorrent.AnnounceResponse
@@ -264,6 +265,7 @@ func (t *Frontend) handleRequest(r Request, w ResponseWriter) (actionName string
 			WriteError(w, txID, ErrInvalidIP)
 			return
 		}
+		af = new(bittorrent.AddressFamily)
 		*af = req.AddressFamily
 
 		var resp *bittorrent.ScrapeResponse


### PR DESCRIPTION
Fixes #291 

I chose to copy the value out rather than reference it, in case we maybe at some point start to recycle these structs too, who knows.