### PR TITLE
frontend/*: only record ClientErrors to Prometheus

### DIFF
--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -39,7 +39,11 @@ var promResponseDurationMilliseconds = prometheus.NewHistogramVec(
 func recordResponseDuration(action string, af *bittorrent.AddressFamily, err error, duration time.Duration) {
 	var errString string
 	if err != nil {
-		errString = err.Error()
+		if _, ok := err.(bittorrent.ClientError); ok {
+			errString = err.Error()
+		} else {
+			errString = "internal error"
+		}
 	}
 
 	var afString string

--- a/frontend/udp/frontend.go
+++ b/frontend/udp/frontend.go
@@ -42,7 +42,11 @@ var promResponseDurationMilliseconds = prometheus.NewHistogramVec(
 func recordResponseDuration(action string, af *bittorrent.AddressFamily, err error, duration time.Duration) {
 	var errString string
 	if err != nil {
-		errString = err.Error()
+		if _, ok := err.(bittorrent.ClientError); ok {
+			errString = err.Error()
+		} else {
+			errString = "internal error"
+		}
 	}
 
 	var afString string


### PR DESCRIPTION
All ClientErrors are constant and should not cause Prometheus streams to
be generated for all possible failure scenarios in the program.

Fixes #294.