### PR TITLE
storage: add prometheus metrics for seeders/leechers

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -78,6 +78,10 @@ chihaya:
     # higher degree of parallelism.
     shard_count: 1024
 
+    # The interval at which metrics about the number of infohashes and peers
+    # are collected and posted to Prometheus.
+    prometheus_reporting_interval: 1s
+
   # This block defines configuration used for middleware executed before a
   # response has been returned to a BitTorrent client.
   prehooks:

--- a/storage/memory/peer_store_test.go
+++ b/storage/memory/peer_store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func createNew() s.PeerStore {
-	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute})
+	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute, PrometheusReportingInterval: 10 * time.Minute})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This adds precise metrics about the number of leechers and seeders to the memory implementation.

This is a pretty big performance hit, maybe we should make it optional? What also annoys me and should maybe be fixed long term is that prometheus uses `float64` for everything (and does expensive floating-point math on these integers). Maybe we can implement something, prometheus only relies on interfaces.

Benchmark:
```
benchmark                               old ns/op     new ns/op     delta
BenchmarkPut                            396           435           +9.85%
BenchmarkPut1k                          399           505           +26.57%
BenchmarkPut1kInfohash                  470           507           +7.87%
BenchmarkPut1kInfohash1k                470           512           +8.94%
BenchmarkPutDelete                      1367          1464          +7.10%
BenchmarkPutDelete1k                    1383          1476          +6.72%
BenchmarkPutDelete1kInfohash            1423          1548          +8.78%
BenchmarkPutDelete1kInfohash1k          1433          1547          +7.96%
BenchmarkDeleteNonexist                 229           224           -2.18%
BenchmarkDeleteNonexist1k               229           229           +0.00%
BenchmarkDeleteNonexist1kInfohash       241           235           -2.49%
BenchmarkDeleteNonexist1kInfohash1k     240           235           -2.08%
BenchmarkPutGradDelete                  2054          2262          +10.13%
BenchmarkPutGradDelete1k                2057          2229          +8.36%
BenchmarkPutGradDelete1kInfohash        2195          2352          +7.15%
BenchmarkPutGradDelete1kInfohash1k      2192          2350          +7.21%
BenchmarkGradNonexist                   428           518           +21.03%
BenchmarkGradNonexist1k                 462           579           +25.32%
BenchmarkGradNonexist1kInfohash         507           614           +21.10%
BenchmarkGradNonexist1kInfohash1k       514           626           +21.79%
BenchmarkAnnounceLeecher                18891         18451         -2.33%
BenchmarkAnnounceLeecher1kInfohash      21211         21271         +0.28%
BenchmarkAnnounceSeeder                 19121         18501         -3.24%
BenchmarkAnnounceSeeder1kInfohash       21361         21171         -0.89%
```