### PR TITLE
Refactor root run command

### DIFF
--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -21,52 +21,21 @@ type hookConfig struct {
 	Config interface{} `yaml:"config"`
 }
 
-// ConfigFile represents a namespaced YAML configation file.
-type ConfigFile struct {
-	MainConfigBlock struct {
-		middleware.Config `yaml:",inline"`
-		PrometheusAddr    string              `yaml:"prometheus_addr"`
-		HTTPConfig        httpfrontend.Config `yaml:"http"`
-		UDPConfig         udpfrontend.Config  `yaml:"udp"`
-		Storage           memory.Config       `yaml:"storage"`
-		PreHooks          []hookConfig        `yaml:"prehooks"`
-		PostHooks         []hookConfig        `yaml:"posthooks"`
-	} `yaml:"chihaya"`
-}
-
-// ParseConfigFile returns a new ConfigFile given the path to a YAML
-// configuration file.
-//
-// It supports relative and absolute paths and environment variables.
-func ParseConfigFile(path string) (*ConfigFile, error) {
-	if path == "" {
-		return nil, errors.New("no config path specified")
-	}
-
-	f, err := os.Open(os.ExpandEnv(path))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	contents, err := ioutil.ReadAll(f)
-	if err != nil {
-		return nil, err
-	}
-
-	var cfgFile ConfigFile
-	err = yaml.Unmarshal(contents, &cfgFile)
-	if err != nil {
-		return nil, err
-	}
-
-	return &cfgFile, nil
+// Config represents the configuration used for executing Chihaya.
+type Config struct {
+	middleware.Config `yaml:",inline"`
+	PrometheusAddr    string              `yaml:"prometheus_addr"`
+	HTTPConfig        httpfrontend.Config `yaml:"http"`
+	UDPConfig         udpfrontend.Config  `yaml:"udp"`
+	Storage           memory.Config       `yaml:"storage"`
+	PreHooks          []hookConfig        `yaml:"prehooks"`
+	PostHooks         []hookConfig        `yaml:"posthooks"`
 }
 
 // CreateHooks creates instances of Hooks for all of the PreHooks and PostHooks
-// configured in a ConfigFile.
-func (cfg ConfigFile) CreateHooks() (preHooks, postHooks []middleware.Hook, err error) {
-	for _, hookCfg := range cfg.MainConfigBlock.PreHooks {
+// configured in a Config.
+func (cfg Config) CreateHooks() (preHooks, postHooks []middleware.Hook, err error) {
+	for _, hookCfg := range cfg.PreHooks {
 		cfgBytes, err := yaml.Marshal(hookCfg.Config)
 		if err != nil {
 			panic("failed to remarshal valid YAML")
@@ -109,10 +78,44 @@ func (cfg ConfigFile) CreateHooks() (preHooks, postHooks []middleware.Hook, err 
 		}
 	}
 
-	for _, hookCfg := range cfg.MainConfigBlock.PostHooks {
+	for _, hookCfg := range cfg.PostHooks {
 		switch hookCfg.Name {
 		}
 	}
 
 	return
+}
+
+// ConfigFile represents a namespaced YAML configation file.
+type ConfigFile struct {
+	Chihaya Config `yaml:"chihaya"`
+}
+
+// ParseConfigFile returns a new ConfigFile given the path to a YAML
+// configuration file.
+//
+// It supports relative and absolute paths and environment variables.
+func ParseConfigFile(path string) (*ConfigFile, error) {
+	if path == "" {
+		return nil, errors.New("no config path specified")
+	}
+
+	f, err := os.Open(os.ExpandEnv(path))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	contents, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfgFile ConfigFile
+	err = yaml.Unmarshal(contents, &cfgFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cfgFile, nil
 }

--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -46,35 +46,35 @@ func (r *Run) Start(ps storage.PeerStore) error {
 		return errors.New("failed to read config: " + err.Error())
 	}
 
-	chihayaCfg := configFile.Chihaya
-	preHooks, postHooks, err := chihayaCfg.CreateHooks()
+	cfg := configFile.Chihaya
+	preHooks, postHooks, err := cfg.CreateHooks()
 	if err != nil {
 		return errors.New("failed to validate hook config: " + err.Error())
 	}
 
 	r.sg = stop.NewGroup()
-	r.sg.Add(prometheus.NewServer(chihayaCfg.PrometheusAddr))
+	r.sg.Add(prometheus.NewServer(cfg.PrometheusAddr))
 
 	if ps == nil {
-		ps, err = memory.New(chihayaCfg.Storage)
+		ps, err = memory.New(cfg.Storage)
 		if err != nil {
 			return errors.New("failed to create memory storage: " + err.Error())
 		}
 	}
 	r.peerStore = ps
 
-	r.logic = middleware.NewLogic(chihayaCfg.Config, r.peerStore, preHooks, postHooks)
+	r.logic = middleware.NewLogic(cfg.Config, r.peerStore, preHooks, postHooks)
 
-	if chihayaCfg.HTTPConfig.Addr != "" {
-		httpfe, err := http.NewFrontend(r.logic, chihayaCfg.HTTPConfig)
+	if cfg.HTTPConfig.Addr != "" {
+		httpfe, err := http.NewFrontend(r.logic, cfg.HTTPConfig)
 		if err != nil {
 			return err
 		}
 		r.sg.Add(httpfe)
 	}
 
-	if chihayaCfg.UDPConfig.Addr != "" {
-		udpfe, err := udp.NewFrontend(r.logic, chihayaCfg.UDPConfig)
+	if cfg.UDPConfig.Addr != "" {
+		udpfe, err := udp.NewFrontend(r.logic, cfg.UDPConfig)
 		if err != nil {
 			return err
 		}

--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -20,11 +20,6 @@ import (
 )
 
 func rootCmdRun(cmd *cobra.Command, args []string) error {
-	debugLog, _ := cmd.Flags().GetBool("debug")
-	if debugLog {
-		log.SetLevel(log.DebugLevel)
-		log.Debugln("debug logging enabled")
-	}
 	cpuProfilePath, _ := cmd.Flags().GetString("cpuprofile")
 	if cpuProfilePath != "" {
 		log.Infoln("enabled CPU profiling to", cpuProfilePath)
@@ -154,7 +149,6 @@ func stopLogic(logic *middleware.Logic, errChan chan error) {
 
 func stop(udpFrontend *udpfrontend.Frontend, httpFrontend *httpfrontend.Frontend, logic *middleware.Logic, errChan chan error, peerStore storage.PeerStore) {
 	stopFrontends(udpFrontend, httpFrontend)
-
 	stopLogic(logic, errChan)
 
 	// Stop storage
@@ -199,6 +193,13 @@ func main() {
 		Use:   "chihaya",
 		Short: "BitTorrent Tracker",
 		Long:  "A customizable, multi-protocol BitTorrent Tracker",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			debugLog, _ := cmd.Flags().GetBool("debug")
+			if debugLog {
+				log.SetLevel(log.DebugLevel)
+				log.Debugln("debug logging enabled")
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := rootCmdRun(cmd, args); err != nil {
 				log.Fatal(err)

--- a/pkg/prometheus/server.go
+++ b/pkg/prometheus/server.go
@@ -1,0 +1,50 @@
+// Package prometheus implements a standalone HTTP server for serving a
+// Prometheus metrics endpoint.
+package prometheus
+
+import (
+	"context"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Server represents a standalone HTTP server for serving a Prometheus metrics
+// endpoint.
+type Server struct {
+	srv *http.Server
+}
+
+// Stop shuts down the server.
+func (s *Server) Stop() <-chan error {
+	c := make(chan error)
+	go func() {
+		if err := s.srv.Shutdown(context.Background()); err != nil {
+			c <- err
+		} else {
+			close(c)
+		}
+	}()
+
+	return c
+}
+
+// NewServer creates a new instance of a Prometheus server that asynchronously
+// serves requests.
+func NewServer(addr string) *Server {
+	s := &Server{
+		srv: &http.Server{
+			Addr:    addr,
+			Handler: prometheus.Handler(),
+		},
+	}
+
+	go func() {
+		if err := s.srv.ListenAndServe(); err != http.ErrServerClosed {
+			log.Fatal("failed while serving prometheus: " + err.Error())
+		}
+	}()
+
+	return s
+}


### PR DESCRIPTION
This change refactors a bunch of the state of execution into its own
object. It also attempts to simplify stopping and adjusts some other
packages to integrate with the stopper interface.

I think it partially fixes #309.

If you build this and spam SIGUSR1 a lot and quickly (using something like `for i in $(seq 1 30); do kill -SIGUSR1 $(pgrep chihaya); done`), you get a fatal exit along the lines of `listen tcp 0.0.0.0:6881: bind: address already in use` from either the Prometheus server or HTTP frontend. I'm not sure what causes it yet, but most of the time it works.