### PR TITLE
bittorrent: create sanitizer object

### DIFF
--- a/bittorrent/bittorrent.go
+++ b/bittorrent/bittorrent.go
@@ -78,13 +78,16 @@ func (i InfoHash) String() string {
 
 // AnnounceRequest represents the parsed parameters from an announce request.
 type AnnounceRequest struct {
-	Event      Event
-	InfoHash   InfoHash
-	Compact    bool
-	NumWant    uint32
-	Left       uint64
-	Downloaded uint64
-	Uploaded   uint64
+	Event           Event
+	InfoHash        InfoHash
+	Compact         bool
+	EventProvided   bool
+	NumWantProvided bool
+	IPProvided      bool
+	NumWant         uint32
+	Left            uint64
+	Downloaded      uint64
+	Uploaded        uint64
 
 	Peer
 	Params

--- a/bittorrent/sanitize.go
+++ b/bittorrent/sanitize.go
@@ -21,12 +21,10 @@ type RequestSanitizer struct {
 // SanitizeAnnounce enforces a max and default NumWant and coerces the a peer's
 // IP address into the proper format.
 func (rs *RequestSanitizer) SanitizeAnnounce(r *AnnounceRequest) (*AnnounceRequest, error) {
-	if r.NumWant > rs.MaxNumWant {
-		r.NumWant = rs.MaxNumWant
-	}
-
-	if r.NumWant == 0 {
+	if !r.NumWantProvided {
 		r.NumWant = rs.DefaultNumWant
+	} else if r.NumWant > rs.MaxNumWant {
+		r.NumWant = rs.MaxNumWant
 	}
 
 	if ip := r.Peer.IP.To4(); ip != nil {

--- a/bittorrent/sanitize.go
+++ b/bittorrent/sanitize.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // ErrInvalidIP indicates an invalid IP for an Announce.

--- a/bittorrent/sanitize.go
+++ b/bittorrent/sanitize.go
@@ -1,0 +1,53 @@
+package bittorrent
+
+import (
+	"errors"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// ErrInvalidIP indicates an invalid IP for an Announce.
+var ErrInvalidIP = errors.New("invalid IP")
+
+// RequestSanitizer is used to replace unreasonable values in requests parsed
+// from a frontend into sane values.
+type RequestSanitizer struct {
+	MaxNumWant          uint32 `yaml:"max_numwant"`
+	DefaultNumWant      uint32 `yaml:"default_numwant"`
+	MaxScrapeInfoHashes uint32 `yaml:"max_scrape_infohashes"`
+}
+
+// SanitizeAnnounce enforces a max and default NumWant and coerces the a peer's
+// IP address into the proper format.
+func (rs *RequestSanitizer) SanitizeAnnounce(r *AnnounceRequest) (*AnnounceRequest, error) {
+	if r.NumWant > rs.MaxNumWant {
+		r.NumWant = rs.MaxNumWant
+	}
+
+	if r.NumWant == 0 {
+		r.NumWant = rs.DefaultNumWant
+	}
+
+	if ip := r.Peer.IP.To4(); ip != nil {
+		r.Peer.IP.IP = ip
+		r.Peer.IP.AddressFamily = IPv4
+	} else if len(r.Peer.IP.IP) == net.IPv6len { // implies r.Peer.IP.To4() == nil
+		r.Peer.IP.AddressFamily = IPv6
+	} else {
+		return r, ErrInvalidIP
+	}
+
+	log.Debugf("sanitized request: %#v", r)
+	return r, nil
+}
+
+// SanitizeScrape enforces a max number of infohashes for a single scrape
+// request.
+func (rs *RequestSanitizer) SanitizeScrape(r *ScrapeRequest) (*ScrapeRequest, error) {
+	if len(r.InfoHashes) > int(rs.MaxScrapeInfoHashes) {
+		r.InfoHashes = r.InfoHashes[:rs.MaxScrapeInfoHashes]
+	}
+
+	return r, nil
+}

--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/chihaya/chihaya/bittorrent"
 	"github.com/chihaya/chihaya/frontend/http"
 	"github.com/chihaya/chihaya/frontend/udp"
 	"github.com/chihaya/chihaya/middleware"
@@ -44,12 +45,13 @@ type storageConfig struct {
 // Config represents the configuration used for executing Chihaya.
 type Config struct {
 	middleware.Config `yaml:",inline"`
-	PrometheusAddr    string        `yaml:"prometheus_addr"`
-	HTTPConfig        http.Config   `yaml:"http"`
-	UDPConfig         udp.Config    `yaml:"udp"`
-	Storage           storageConfig `yaml:"storage"`
-	PreHooks          hookConfigs   `yaml:"prehooks"`
-	PostHooks         hookConfigs   `yaml:"posthooks"`
+	RequestSanitizer  bittorrent.RequestSanitizer `yaml:",inline"`
+	PrometheusAddr    string                      `yaml:"prometheus_addr"`
+	HTTPConfig        http.Config                 `yaml:"http"`
+	UDPConfig         udp.Config                  `yaml:"udp"`
+	Storage           storageConfig               `yaml:"storage"`
+	PreHooks          hookConfigs                 `yaml:"prehooks"`
+	PostHooks         hookConfigs                 `yaml:"posthooks"`
 }
 
 // CreateHooks creates instances of Hooks for all of the PreHooks and PostHooks

--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -73,7 +73,7 @@ func (r *Run) Start(ps storage.PeerStore) error {
 
 	if cfg.HTTPConfig.Addr != "" {
 		log.Info("starting HTTP frontend", cfg.HTTPConfig.LogFields())
-		httpfe, err := http.NewFrontend(r.logic, cfg.HTTPConfig)
+		httpfe, err := http.NewFrontend(r.logic, &cfg.RequestSanitizer, cfg.HTTPConfig)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func (r *Run) Start(ps storage.PeerStore) error {
 
 	if cfg.UDPConfig.Addr != "" {
 		log.Info("starting UDP frontend", cfg.UDPConfig.LogFields())
-		udpfe, err := udp.NewFrontend(r.logic, cfg.UDPConfig)
+		udpfe, err := udp.NewFrontend(r.logic, &cfg.RequestSanitizer, cfg.UDPConfig)
 		if err != nil {
 			return err
 		}

--- a/frontend/http/parser.go
+++ b/frontend/http/parser.go
@@ -7,12 +7,12 @@ import (
 	"github.com/chihaya/chihaya/bittorrent"
 )
 
-// ParseAnnounce parses an bittorrent.AnnounceRequest from an http.Request.
+// ParseAnnounce parses a bittorrent.AnnounceRequest from an http.Request.
 //
 // If allowIPSpoofing is true, IPs provided via params will be used.
 // If realIPHeader is not empty string, the first value of the HTTP Header with
 // that name will be used.
-func ParseAnnounce(r *http.Request, realIPHeader string, allowIPSpoofing bool) (*bittorrent.AnnounceRequest, error) {
+func ParseAnnounce(r *http.Request, rs *bittorrent.RequestSanitizer, realIPHeader string, allowIPSpoofing bool) (*bittorrent.AnnounceRequest, error) {
 	qp, err := bittorrent.ParseURLData(r.RequestURI)
 	if err != nil {
 		return nil, err
@@ -79,11 +79,11 @@ func ParseAnnounce(r *http.Request, realIPHeader string, allowIPSpoofing bool) (
 		return nil, bittorrent.ClientError("failed to parse peer IP address")
 	}
 
-	return request, nil
+	return rs.SanitizeAnnounce(request)
 }
 
 // ParseScrape parses an bittorrent.ScrapeRequest from an http.Request.
-func ParseScrape(r *http.Request) (*bittorrent.ScrapeRequest, error) {
+func ParseScrape(r *http.Request, rs *bittorrent.RequestSanitizer) (*bittorrent.ScrapeRequest, error) {
 	qp, err := bittorrent.ParseURLData(r.RequestURI)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func ParseScrape(r *http.Request) (*bittorrent.ScrapeRequest, error) {
 		Params:     qp,
 	}
 
-	return request, nil
+	return rs.SanitizeScrape(request)
 }
 
 // requestedIP determines the IP address for a BitTorrent client request.

--- a/frontend/udp/parser.go
+++ b/frontend/udp/parser.go
@@ -48,11 +48,10 @@ var (
 // ParseAnnounce parses an AnnounceRequest from a UDP request.
 //
 // If allowIPSpoofing is true, IPs provided via params will be used.
-//
 // If v6 is true the announce will be parsed as an IPv6 announce "the
-// opentracker way", see
+// opentracker way":
 // http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/
-func ParseAnnounce(r Request, allowIPSpoofing, v6 bool) (*bittorrent.AnnounceRequest, error) {
+func ParseAnnounce(r Request, rs *bittorrent.RequestSanitizer, allowIPSpoofing, v6 bool) (*bittorrent.AnnounceRequest, error) {
 	ipEnd := 84 + net.IPv4len
 	if v6 {
 		ipEnd = 84 + net.IPv6len
@@ -92,7 +91,7 @@ func ParseAnnounce(r Request, allowIPSpoofing, v6 bool) (*bittorrent.AnnounceReq
 		return nil, err
 	}
 
-	return &bittorrent.AnnounceRequest{
+	return rs.SanitizeAnnounce(&bittorrent.AnnounceRequest{
 		Event:      eventIDs[eventID],
 		InfoHash:   bittorrent.InfoHashFromBytes(infohash),
 		NumWant:    uint32(numWant),
@@ -105,7 +104,7 @@ func ParseAnnounce(r Request, allowIPSpoofing, v6 bool) (*bittorrent.AnnounceReq
 			Port: port,
 		},
 		Params: params,
-	}, nil
+	})
 }
 
 type buffer struct {
@@ -170,7 +169,7 @@ func handleOptionalParameters(packet []byte) (bittorrent.Params, error) {
 }
 
 // ParseScrape parses a ScrapeRequest from a UDP request.
-func ParseScrape(r Request) (*bittorrent.ScrapeRequest, error) {
+func ParseScrape(r Request, rs *bittorrent.RequestSanitizer) (*bittorrent.ScrapeRequest, error) {
 	// If a scrape isn't at least 36 bytes long, it's malformed.
 	if len(r.Packet) < 36 {
 		return nil, errMalformedPacket
@@ -190,7 +189,7 @@ func ParseScrape(r Request) (*bittorrent.ScrapeRequest, error) {
 		r.Packet = r.Packet[20:]
 	}
 
-	return &bittorrent.ScrapeRequest{
+	return rs.SanitizeScrape(&bittorrent.ScrapeRequest{
 		InfoHashes: infohashes,
-	}, nil
+	})
 }

--- a/frontend/udp/parser.go
+++ b/frontend/udp/parser.go
@@ -73,10 +73,12 @@ func ParseAnnounce(r Request, rs *bittorrent.RequestSanitizer, allowIPSpoofing, 
 	}
 
 	ip := r.IP
+	ipProvided := false
 	ipbytes := r.Packet[84:ipEnd]
 	if allowIPSpoofing {
 		// Make sure the bytes are copied to a new slice.
 		copy(ip, net.IP(ipbytes))
+		ipProvided = true
 	}
 	if !allowIPSpoofing && r.IP == nil {
 		// We have no IP address to fallback on.
@@ -92,12 +94,15 @@ func ParseAnnounce(r Request, rs *bittorrent.RequestSanitizer, allowIPSpoofing, 
 	}
 
 	return rs.SanitizeAnnounce(&bittorrent.AnnounceRequest{
-		Event:      eventIDs[eventID],
-		InfoHash:   bittorrent.InfoHashFromBytes(infohash),
-		NumWant:    uint32(numWant),
-		Left:       left,
-		Downloaded: downloaded,
-		Uploaded:   uploaded,
+		Event:           eventIDs[eventID],
+		InfoHash:        bittorrent.InfoHashFromBytes(infohash),
+		NumWant:         uint32(numWant),
+		Left:            left,
+		Downloaded:      downloaded,
+		Uploaded:        uploaded,
+		IPProvided:      ipProvided,
+		NumWantProvided: true,
+		EventProvided:   true,
 		Peer: bittorrent.Peer{
 			ID:   bittorrent.PeerIDFromBytes(peerID),
 			IP:   bittorrent.IP{IP: ip},

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: afe26469a328ec99dd3c4b8cc86d407ad72f65d9053ae9c3bec6d447d34d8189
-updated: 2017-07-03T18:55:10.538458698-04:00
+hash: d248b8c67f414ff39e9f871303661b34377a61417a5e288e69cdc57e266707b7
+updated: 2017-08-12T21:56:22.223648559-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/golang/protobuf
-  version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
+  version: 1909bc2f63dc92bb931deace8b8312c4db72d12f
   subpackages:
   - proto
 - name: github.com/inconshreveable/mousetrap
@@ -38,7 +38,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 0866df4b85a18d652b6965be022d007cdf076822
+  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -54,9 +54,9 @@ imports:
   - jws
   - jwt
 - name: github.com/sirupsen/logrus
-  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
+  version: a3f95b5c423586578a4e099b11a46c2479628cac
 - name: github.com/spf13/cobra
-  version: 8c6fa02d2225de0f9bdcb7ca912556f68d172d8c
+  version: b26b538f693051ac6518e65672de3144ce3fbedc
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/stretchr/testify
@@ -65,9 +65,9 @@ imports:
   - assert
   - require
 - name: golang.org/x/sys
-  version: 94b76065f2d2081d0fef24a6e67c571f51a6408a
+  version: e42485b6e20ae7d2304ec72e535b103ed350cc02
   subpackages:
   - unix
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,6 @@ import:
   - crypto
   - jws
   - jwt
-- package: github.com/sirupsen/logrus
-  version: ~1.0.0
 - package: github.com/julienschmidt/httprouter
   version: ~1.1.0
 - package: github.com/mendsley/gojwk
@@ -16,6 +14,8 @@ import:
   version: ~0.8.0
   subpackages:
   - prometheus
+- package: github.com/sirupsen/logrus
+  version: ~1.0.2
 - package: github.com/spf13/cobra
 - package: github.com/stretchr/testify
   version: ~1.1.4

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -15,10 +15,7 @@ import (
 
 // Config holds the configuration common across all middleware.
 type Config struct {
-	AnnounceInterval    time.Duration `yaml:"announce_interval"`
-	MaxNumWant          uint32        `yaml:"max_numwant"`
-	DefaultNumWant      uint32        `yaml:"default_numwant"`
-	MaxScrapeInfoHashes uint32        `yaml:"max_scrape_infohashes"`
+	AnnounceInterval time.Duration `yaml:"announce_interval"`
 }
 
 var _ frontend.TrackerLogic = &Logic{}
@@ -29,7 +26,6 @@ func NewLogic(cfg Config, peerStore storage.PeerStore, preHooks, postHooks []Hoo
 	l := &Logic{
 		announceInterval: cfg.AnnounceInterval,
 		peerStore:        peerStore,
-		preHooks:         []Hook{&sanitizationHook{cfg.MaxNumWant, cfg.DefaultNumWant, cfg.MaxScrapeInfoHashes}},
 		postHooks:        append(postHooks, &swarmInteractionHook{store: peerStore}),
 	}
 

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -80,15 +80,4 @@ func BenchmarkHookOverhead(b *testing.B) {
 			benchHookListV6(b, nopHooks)
 		})
 	}
-
-	var sanHooks hookList
-	for i := 1; i < 4; i++ {
-		sanHooks = append(sanHooks, &sanitizationHook{maxNumWant: 50})
-		b.Run(fmt.Sprintf("%dsanitation-v4", i), func(b *testing.B) {
-			benchHookListV4(b, sanHooks)
-		})
-		b.Run(fmt.Sprintf("%dsanitation-v6", i), func(b *testing.B) {
-			benchHookListV6(b, sanHooks)
-		})
-	}
 }


### PR DESCRIPTION
This consolidates the logic by which a request is valid into the bittorrent library rather than being implemented by individual frontends.