### PR TITLE
storage/config: fix example config, add warning for missing shardCount

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -68,7 +68,7 @@ chihaya:
 
     # The number of partitions data will be divided into in order to provide a
     # higher degree of parallelism.
-    shards: 1024
+    shard_count: 1024
 
   # This block defines configuration used for middleware executed before a
   # response has been returned to a BitTorrent client.

--- a/storage/memory/peer_store.go
+++ b/storage/memory/peer_store.go
@@ -63,9 +63,12 @@ func (cfg Config) LogFields() log.Fields {
 
 // New creates a new PeerStore backed by memory.
 func New(cfg Config) (storage.PeerStore, error) {
-	shardCount := 1
+	var shardCount int
 	if cfg.ShardCount > 0 {
 		shardCount = cfg.ShardCount
+	} else {
+		log.Warnln("storage: shardCount not configured, using 1 as default value.")
+		shardCount = 1
 	}
 
 	if cfg.GarbageCollectionInterval <= 0 {


### PR DESCRIPTION
@jzelinskie your logging of config values brought this up. Apparently our example config was wrong the whole time ¯\\_(ツ)_/¯

Qualitative `tbomb` benchmark on my laptop:
Before, 1024 shards configured, actually using one shard:
```
Dispatching 200 clients
Waiting for results...

Requests:                           578724
Successful requests:                578535
failed requests:                       189
Connect attempts:                      200
Failed connects:                         0
Successful requests rate:            57851 hits/sec
Approximate concurrency:            200.00 clients running
Test time:                           10.00 sec
Errors encountered:
```


After, actually 1024 shards:
```
Dispatching 200 clients
Waiting for results...

Requests:                           641252
Successful requests:                641062
failed requests:                       190
Connect attempts:                      200
Failed connects:                         0
Successful requests rate:            64103 hits/sec
Approximate concurrency:            200.00 clients running
Test time:                           10.00 sec
Errors encountered:
```