### PR TITLE
storage/memory: set default prometheus_reporting_interval

### DIFF
--- a/storage/memory/peer_store.go
+++ b/storage/memory/peer_store.go
@@ -125,6 +125,10 @@ func New(cfg Config) (storage.PeerStore, error) {
 	ps.wg.Add(1)
 	go func() {
 		defer ps.wg.Done()
+		if cfg.PrometheusReportingInterval <= 0 {
+			cfg.PrometheusReportingInterval = 1
+			log.Warn("storage: PrometheusReportingInterval not specified/invalid, defaulting to 1 second")
+		}
 		t := time.NewTicker(cfg.PrometheusReportingInterval)
 		for {
 			select {


### PR DESCRIPTION
When left blank in the config, the default prometheus_reporting_interval value
defaulted to 0, causing a panic during peer store initialization. This
change sets the default value to 1 if not provided.