### PR TITLE
middleware/jwt: escape infohash when debugging

### DIFF
--- a/middleware/jwt/jwt.go
+++ b/middleware/jwt/jwt.go
@@ -175,7 +175,7 @@ func validateJWT(ih bittorrent.InfoHash, jwtBytes []byte, cfgIss, cfgAud string,
 	if ihClaim, ok := claims.Get("infohash").(string); !ok || !validInfoHash(ihClaim, ih) {
 		log.WithFields(log.Fields{
 			"exists":  ok,
-			"request": ih,
+			"request": url.QueryEscape(ih.String()),
 			"claim":   ihClaim,
 		}).Debugln("unequal or missing infohash when validating JWT")
 		return errors.New("claim \"infohash\" is invalid")


### PR DESCRIPTION
Without this, the log lines end up looking like:
request=��1�H�7L a���-��7