### PR TITLE
glide: update dependencies

### DIFF
--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/chihaya/chihaya/frontend/http"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ba0c138fa4c3c1f55ce0bce72afb19e67be67edc48be86297440dae521cfee57
-updated: 2017-02-18T13:02:38.493823158+01:00
+hash: afe26469a328ec99dd3c4b8cc86d407ad72f65d9053ae9c3bec6d447d34d8189
+updated: 2017-07-03T18:55:10.538458698-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
   subpackages:
   - proto
 - name: github.com/inconshreveable/mousetrap
@@ -24,7 +24,7 @@ imports:
 - name: github.com/mendsley/gojwk
   version: 4d5ec6e58103388d6cb0d7d72bc72649be4f0504
 - name: github.com/minio/sha256-simd
-  version: e82e73b775766b9011503e80e6772fc32b9afc5b
+  version: f3ec2e4d36d43c3a899ed4b7d9f62188edcf5afd
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -34,38 +34,40 @@ imports:
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: dd2f054febf4a6c00f2343686efb775948a8bff4
+  version: 0866df4b85a18d652b6965be022d007cdf076822
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  subpackages:
+  - xfs
 - name: github.com/SermoDigital/jose
   version: f6df55f235c24f236d11dbcf665249a59ac2021f
   subpackages:
   - crypto
   - jws
   - jwt
-- name: github.com/Sirupsen/logrus
-  version: c078b1e43f58d563c74cebe63c85789e76ddb627
+- name: github.com/sirupsen/logrus
+  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: github.com/spf13/cobra
-  version: 0f056af21f5f368e5b0646079d0094a2c64150f7
+  version: 8c6fa02d2225de0f9bdcb7ca912556f68d172d8c
 - name: github.com/spf13/pflag
-  version: a9a634f3de0a7529baded7ad6b0c7467d5c6eca7
+  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: 94b76065f2d2081d0fef24a6e67c571f51a6408a
   subpackages:
   - unix
 - name: gopkg.in/yaml.v2
-  version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,24 +1,24 @@
 package: github.com/chihaya/chihaya
 import:
 - package: github.com/SermoDigital/jose
-  version: ^1.1.0
+  version: ~1.1.0
   subpackages:
   - crypto
   - jws
   - jwt
-- package: github.com/Sirupsen/logrus
-  version: ^0.11.2
+- package: github.com/sirupsen/logrus
+  version: ~1.0.0
 - package: github.com/julienschmidt/httprouter
-  version: ^1.1.0
+  version: ~1.1.0
 - package: github.com/mendsley/gojwk
 - package: github.com/minio/sha256-simd
 - package: github.com/prometheus/client_golang
-  version: ^0.8.0
+  version: ~0.8.0
   subpackages:
   - prometheus
 - package: github.com/spf13/cobra
 - package: github.com/stretchr/testify
-  version: ^1.1.4
+  version: ~1.1.4
   subpackages:
   - require
 - package: gopkg.in/yaml.v2

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -5,7 +5,7 @@ package log
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
This change also moves the logrus library to the lowercase import in
order to avoid breaking downstream projects vendoring chihaya.