### PR TITLE
storage: add PeerLifetime to test config

### DIFF
--- a/storage/memory/peer_store_test.go
+++ b/storage/memory/peer_store_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func createNew() s.PeerStore {
-	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute, PrometheusReportingInterval: 10 * time.Minute})
+	ps, err := New(Config{ShardCount: 1024, GarbageCollectionInterval: 10 * time.Minute, PrometheusReportingInterval: 10 * time.Minute, PeerLifetime: 30 * time.Minute})
 	if err != nil {
 		panic(err)
 	}

--- a/storage/memorybysubnet/peer_store_test.go
+++ b/storage/memorybysubnet/peer_store_test.go
@@ -11,6 +11,7 @@ func createNew() s.PeerStore {
 	ps, err := New(Config{
 		ShardCount:                     1024,
 		GarbageCollectionInterval:      10 * time.Minute,
+		PeerLifetime:                   30 * time.Minute,
 		PreferredIPv4SubnetMaskBitsSet: 31,
 		PreferredIPv6SubnetMaskBitsSet: 64,
 	})


### PR DESCRIPTION
Otherwise we get nasty warnings about using the default value when benchmarking or testing.