### PR TITLE
cmd/chihaya: make things work on windows

### DIFF
--- a/cmd/chihaya/signal_unix.go
+++ b/cmd/chihaya/signal_unix.go
@@ -1,0 +1,15 @@
+// +build darwin freebsd linux netbsd openbsd dragonfly solaris
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func makeReloadChan() <-chan os.Signal {
+	reload := make(chan os.Signal)
+	signal.Notify(reload, syscall.SIGUSR1)
+	return reload
+}

--- a/cmd/chihaya/signal_windows.go
+++ b/cmd/chihaya/signal_windows.go
@@ -1,0 +1,15 @@
+// +build windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func makeReloadChan() <-chan os.Signal {
+	reload := make(chan os.Signal)
+	signal.Notify(reload, syscall.SIGHUP)
+	return reload
+}


### PR DESCRIPTION
Fixes #302

Also makes it so that logging on windows has coloring disabled by default.

Before:
```
?[36mINFO?[0m[0000] starting Prometheus server                    ?[36maddr?[0m="0.0.0.0:6880"
?[36mINFO?[0m[0000] starting storage                              ?[36mname?[0m=memory
?[36mINFO?[0m[0000] started storage                               ?[36mgcInterval?[0m=3m0s ?[36mname?[0m=memory ?[36mpeerLifetime?[0m=16m0s ?[36mpromReportInterval?[0m=1s ?[36mshardCount?[0m=1024
?[36mINFO?[0m[0000] starting middleware                           ?[36mpostHooks?[0m="[]" ?[36mpreHooks?[0m="[]"
?[36mINFO?[0m[0000] starting HTTP frontend                        ?[36maddr?[0m="0.0.0.0:6881" ?[36mallowIPSpoofing?[0m=true ?[36mdefaultNumWant?[0m=50 ?[36menableRequestTiming?[0m=true ?[36mmaxNumWant?[0m=100 ?[36mmaxScrapeInfoHashes?[0m=50 ?[36mreadTimeout?[0m
=5s ?[36mrealIPHeader?[0m= ?[36mtlsCertPath?[0m= ?[36mtlsKeyPath?[0m= ?[36mwriteTimeout?[0m=5s
?[36mINFO?[0m[0000] starting UDP frontend                         ?[36maddr?[0m="0.0.0.0:6881" ?[36mallowIPSpoofing?[0m=true ?[36mdefaultNumWant?[0m=50 ?[36menableRequestTiming?[0m=true ?[36mmaxClockSkew?[0m=10s ?[36mmaxNumWant?[0m=100 ?[36mmaxScrapeInfoHashes?[
0m=50 ?[36mprivateKey?[0m="paste a random string here that will be used to hmac connection IDs"
?[36mINFO?[0m[0001] shutting down; received SIGINT/SIGTERM
```

After:
```
time="2017-12-05T10:08:03+01:00" level=info msg="starting Prometheus server" addr="0.0.0.0:6880"
time="2017-12-05T10:08:03+01:00" level=info msg="starting storage" name=memory
time="2017-12-05T10:08:03+01:00" level=info msg="started storage" gcInterval=3m0s name=memory peerLifetime=16m0s promReportInterval=1s shardCount=1024
time="2017-12-05T10:08:03+01:00" level=info msg="starting middleware" postHooks="[]" preHooks="[]"
time="2017-12-05T10:08:03+01:00" level=info msg="starting HTTP frontend" addr="0.0.0.0:6881" allowIPSpoofing=true defaultNumWant=50 enableRequestTiming=true maxNumWant=100 maxScrapeInfoHashes=50 readTimeout=5s realIPHeader= tlsCertPath= tlsKeyPath= writeTimeout=
5s
time="2017-12-05T10:08:03+01:00" level=info msg="starting UDP frontend" addr="0.0.0.0:6881" allowIPSpoofing=true defaultNumWant=50 enableRequestTiming=true maxClockSkew=10s maxNumWant=100 maxScrapeInfoHashes=50 privateKey="paste a random string here that will be
 used to hmac connection IDs"
time="2017-12-05T10:08:07+01:00" level=info msg="shutting down; received SIGINT/SIGTERM"
```

I have no clue why the entire format changed - I just disabled colors...