### PR TITLE
*: add subtests for all table driven tests

### DIFF
--- a/bittorrent/client_id_test.go
+++ b/bittorrent/client_id_test.go
@@ -43,11 +43,13 @@ func TestClientID(t *testing.T) {
 	}
 
 	for _, tt := range clientTable {
-		var clientID ClientID
-		copy(clientID[:], []byte(tt.clientID))
-		parsedID := NewClientID(PeerIDFromString(tt.peerID))
-		if parsedID != clientID {
-			t.Error("Incorrectly parsed peer ID", tt.peerID, "as", parsedID)
-		}
+		t.Run(tt.peerID, func(t *testing.T) {
+			var clientID ClientID
+			copy(clientID[:], []byte(tt.clientID))
+			parsedID := NewClientID(PeerIDFromString(tt.peerID))
+			if parsedID != clientID {
+				t.Error("Incorrectly parsed peer ID", tt.peerID, "as", parsedID)
+			}
+		})
 	}
 }

--- a/bittorrent/event_test.go
+++ b/bittorrent/event_test.go
@@ -23,10 +23,17 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		t.Run(fmt.Sprintf("%#v expecting %s", tt.data, tt.expectedErr), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%#v expecting %s", tt.data, nilPrinter(tt.expectedErr)), func(t *testing.T) {
 			got, err := NewEvent(tt.data)
 			require.Equal(t, err, tt.expectedErr, "errors should equal the expected value")
 			require.Equal(t, got, tt.expected, "events should equal the expected value")
 		})
 	}
+}
+
+func nilPrinter(err error) string {
+	if err == nil {
+		return "nil"
+	}
+	return err.Error()
 }

--- a/bittorrent/event_test.go
+++ b/bittorrent/event_test.go
@@ -1,6 +1,7 @@
 package bittorrent
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,8 +23,10 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		got, err := NewEvent(tt.data)
-		require.Equal(t, err, tt.expectedErr, "errors should equal the expected value")
-		require.Equal(t, got, tt.expected, "events should equal the expected value")
+		t.Run(fmt.Sprintf("%#v expecting %s", tt.data, tt.expectedErr), func(t *testing.T) {
+			got, err := NewEvent(tt.data)
+			require.Equal(t, err, tt.expectedErr, "errors should equal the expected value")
+			require.Equal(t, got, tt.expected, "events should equal the expected value")
+		})
 	}
 }

--- a/frontend/http/bencode/decoder_test.go
+++ b/frontend/http/bencode/decoder_test.go
@@ -24,9 +24,11 @@ var unmarshalTests = []struct {
 
 func TestUnmarshal(t *testing.T) {
 	for _, tt := range unmarshalTests {
-		got, err := Unmarshal([]byte(tt.input))
-		require.Nil(t, err, "unmarshal should not fail")
-		require.Equal(t, got, tt.expected, "unmarshalled values should match the expected results")
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := Unmarshal([]byte(tt.input))
+			require.Nil(t, err, "unmarshal should not fail")
+			require.Equal(t, got, tt.expected, "unmarshalled values should match the expected results")
+		})
 	}
 }
 

--- a/frontend/http/bencode/encoder_test.go
+++ b/frontend/http/bencode/encoder_test.go
@@ -2,6 +2,7 @@ package bencode
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,10 +36,12 @@ var marshalTests = []struct {
 }
 
 func TestMarshal(t *testing.T) {
-	for _, test := range marshalTests {
-		got, err := Marshal(test.input)
-		require.Nil(t, err, "marshal should not fail")
-		require.Contains(t, test.expected, string(got), "the marshaled result should be one of the expected permutations")
+	for _, tt := range marshalTests {
+		t.Run(fmt.Sprintf("%#v", tt.input), func(t *testing.T) {
+			got, err := Marshal(tt.input)
+			require.Nil(t, err, "marshal should not fail")
+			require.Contains(t, tt.expected, string(got), "the marshaled result should be one of the expected permutations")
+		})
 	}
 }
 

--- a/frontend/http/writer_test.go
+++ b/frontend/http/writer_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"testing"
 
@@ -18,16 +19,28 @@ func TestWriteError(t *testing.T) {
 	}
 
 	for _, tt := range table {
-		r := httptest.NewRecorder()
-		err := WriteError(r, bittorrent.ClientError(tt.reason))
-		require.Nil(t, err)
-		require.Equal(t, r.Body.String(), tt.expected)
+		t.Run(fmt.Sprintf("%s expecting %s", tt.reason, tt.expected), func(t *testing.T) {
+			r := httptest.NewRecorder()
+			err := WriteError(r, bittorrent.ClientError(tt.reason))
+			require.Nil(t, err)
+			require.Equal(t, r.Body.String(), tt.expected)
+		})
 	}
 }
 
 func TestWriteStatus(t *testing.T) {
-	r := httptest.NewRecorder()
-	err := WriteError(r, bittorrent.ClientError("something is missing"))
-	require.Nil(t, err)
-	require.Equal(t, r.Body.String(), "d14:failure reason20:something is missinge")
+	var table = []struct {
+		reason, expected string
+	}{
+		{"something is missing", "d14:failure reason20:something is missinge"},
+	}
+
+	for _, tt := range table {
+		t.Run(fmt.Sprintf("%s expecting %s", tt.reason, tt.expected), func(t *testing.T) {
+			r := httptest.NewRecorder()
+			err := WriteError(r, bittorrent.ClientError(tt.reason))
+			require.Nil(t, err)
+			require.Equal(t, r.Body.String(), tt.expected)
+		})
+	}
 }

--- a/frontend/udp/connection_id_test.go
+++ b/frontend/udp/connection_id_test.go
@@ -1,6 +1,7 @@
 package udp
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -20,11 +21,13 @@ var golden = []struct {
 
 func TestVerification(t *testing.T) {
 	for _, tt := range golden {
-		cid := NewConnectionID(net.ParseIP(tt.ip), time.Unix(tt.createdAt, 0), tt.key)
-		got := ValidConnectionID(cid, net.ParseIP(tt.ip), time.Unix(tt.now, 0), time.Minute, tt.key)
-		if got != tt.valid {
-			t.Errorf("expected validity: %t got validity: %t", tt.valid, got)
-		}
+		t.Run(fmt.Sprintf("%s created at %d verified at %d", tt.ip, tt.createdAt, tt.now), func(t *testing.T) {
+			cid := NewConnectionID(net.ParseIP(tt.ip), time.Unix(tt.createdAt, 0), tt.key)
+			got := ValidConnectionID(cid, net.ParseIP(tt.ip), time.Unix(tt.now, 0), time.Minute, tt.key)
+			if got != tt.valid {
+				t.Errorf("expected validity: %t got validity: %t", tt.valid, got)
+			}
+		})
 	}
 }
 

--- a/frontend/udp/parser_test.go
+++ b/frontend/udp/parser_test.go
@@ -1,6 +1,9 @@
 package udp
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 var table = []struct {
 	data   []byte
@@ -45,27 +48,29 @@ var table = []struct {
 }
 
 func TestHandleOptionalParameters(t *testing.T) {
-	for _, testCase := range table {
-		params, err := handleOptionalParameters(testCase.data)
-		if err != testCase.err {
-			if testCase.err == nil {
-				t.Fatalf("expected no parsing error for %x but got %s", testCase.data, err)
-			} else {
-				t.Fatalf("expected parsing error for %x", testCase.data)
+	for _, tt := range table {
+		t.Run(fmt.Sprintf("%#v as %#v", tt.data, tt.values), func(t *testing.T) {
+			params, err := handleOptionalParameters(tt.data)
+			if err != tt.err {
+				if tt.err == nil {
+					t.Fatalf("expected no parsing error for %x but got %s", tt.data, err)
+				} else {
+					t.Fatalf("expected parsing error for %x", tt.data)
+				}
 			}
-		}
-		if testCase.values != nil {
-			if params == nil {
-				t.Fatalf("expected values %v for %x", testCase.values, testCase.data)
-			} else {
-				for key, want := range testCase.values {
-					if got, ok := params.String(key); !ok {
-						t.Fatalf("params missing entry %s for data %x", key, testCase.data)
-					} else if got != want {
-						t.Fatalf("expected param %s=%s, but was %s for data %x", key, want, got, testCase.data)
+			if tt.values != nil {
+				if params == nil {
+					t.Fatalf("expected values %v for %x", tt.values, tt.data)
+				} else {
+					for key, want := range tt.values {
+						if got, ok := params.String(key); !ok {
+							t.Fatalf("params missing entry %s for data %x", key, tt.data)
+						} else if got != want {
+							t.Fatalf("expected param %s=%s, but was %s for data %x", key, want, got, tt.data)
+						}
 					}
 				}
 			}
-		}
+		})
 	}
 }

--- a/middleware/varinterval/varinterval_test.go
+++ b/middleware/varinterval/varinterval_test.go
@@ -2,6 +2,7 @@ package varinterval
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/chihaya/chihaya/bittorrent"
@@ -34,10 +35,10 @@ var configTests = []struct {
 }
 
 func TestCheckConfig(t *testing.T) {
-	for _, tc := range configTests {
-		t.Run("", func(t *testing.T) {
-			got := checkConfig(tc.cfg)
-			require.Equal(t, tc.expected, got, "", tc.cfg)
+	for _, tt := range configTests {
+		t.Run(fmt.Sprintf("%#v", tt.cfg), func(t *testing.T) {
+			got := checkConfig(tt.cfg)
+			require.Equal(t, tt.expected, got, "", tt.cfg)
 		})
 	}
 }


### PR DESCRIPTION
Because we use testify, this is less useful than normal, but this is
still best practice for table-driven tests.