### PR TITLE
Opentracker v6

### DIFF
--- a/cmd/chihaya-e2e/main.go
+++ b/cmd/chihaya-e2e/main.go
@@ -15,8 +15,8 @@ import (
 )
 
 func init() {
-	flag.StringVar(&httpTrackerURL, "http", "http://localhost:6969/announce", "the address of the HTTP tracker")
-	flag.StringVar(&udpTrackerURL, "udp", "udp://localhost:6969", "the address of the UDP tracker")
+	flag.StringVar(&httpTrackerURL, "http", "http://127.0.0.1:6969/announce", "the address of the HTTP tracker")
+	flag.StringVar(&udpTrackerURL, "udp", "udp://127.0.0.1:6969", "the address of the UDP tracker")
 	flag.DurationVar(&delay, "delay", 1*time.Second, "the delay between announces")
 }
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -21,7 +21,8 @@ It listens for requests and usually answers each of them with one response, a ba
 
 Chihaya ships with frontends for HTTP(S) and UDP.
 The HTTP frontend uses Go's `http` package.
-The UDP frontend implements [opentracker-style] IPv6, contrary to the specification in [BEP 15].
+The UDP frontend implements both [old-opentracker-style] IPv6 and the IPv6 support specified in [BEP 15].
+The advantage of the old opentracker style is that it contains a usable IPv6 `ip` field, to enable IP overrides in announces.
 
 ## Implementing a Frontend
 
@@ -105,4 +106,4 @@ This way, a PreHook can communicate with a PostHook by setting a context value.
 [BEP 3]: http://bittorrent.org/beps/bep_0003.html
 [BEP 15]: http://bittorrent.org/beps/bep_0015.html
 [Prometheus]: https://prometheus.io/
-[opentracker-style]: http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/
+[old-opentracker-style]: https://web.archive.org/web/20170503181830/http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/

--- a/frontend/udp/frontend.go
+++ b/frontend/udp/frontend.go
@@ -306,7 +306,7 @@ func (t *Frontend) handleRequest(r Request, w ResponseWriter) (actionName string
 			return
 		}
 
-		WriteAnnounce(w, txID, resp, actionID == announceV6ActionID)
+		WriteAnnounce(w, txID, resp, actionID == announceV6ActionID, req.IP.AddressFamily == bittorrent.IPv6)
 
 		go t.logic.AfterAnnounce(ctx, req, resp)
 

--- a/frontend/udp/parser.go
+++ b/frontend/udp/parser.go
@@ -15,6 +15,9 @@ const (
 	announceActionID
 	scrapeActionID
 	errorActionID
+	// action == 4 is the "old" IPv6 action used by opentracker, with a packet
+	// format specified at
+	// https://web.archive.org/web/20170503181830/http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/
 	announceV6ActionID
 )
 
@@ -57,11 +60,12 @@ type ParseOptions struct {
 
 // ParseAnnounce parses an AnnounceRequest from a UDP request.
 //
-// If v6 is true, the announce is parsed the "opentracker way":
-// http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/
-func ParseAnnounce(r Request, v6 bool, opts ParseOptions) (*bittorrent.AnnounceRequest, error) {
+// If v6Action is true, the announce is parsed the
+// "old opentracker way":
+// https://web.archive.org/web/20170503181830/http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/
+func ParseAnnounce(r Request, v6Action bool, opts ParseOptions) (*bittorrent.AnnounceRequest, error) {
 	ipEnd := 84 + net.IPv4len
-	if v6 {
+	if v6Action {
 		ipEnd = 84 + net.IPv6len
 	}
 

--- a/frontend/udp/writer.go
+++ b/frontend/udp/writer.go
@@ -26,12 +26,13 @@ func WriteError(w io.Writer, txID []byte, err error) {
 
 // WriteAnnounce encodes an announce response according to BEP 15.
 // The peers returned will be resp.IPv6Peers or resp.IPv4Peers, depending on
-// whether v6 is set. The action ID will be 4, according to
-// http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/.
-func WriteAnnounce(w io.Writer, txID []byte, resp *bittorrent.AnnounceResponse, v6 bool) {
+// whether v6Peers is set.
+// If v6Action is set, the action will be 4, according to
+// https://web.archive.org/web/20170503181830/http://opentracker.blog.h3q.com/2007/12/28/the-ipv6-situation/
+func WriteAnnounce(w io.Writer, txID []byte, resp *bittorrent.AnnounceResponse, v6Action, v6Peers bool) {
 	buf := newBuffer()
 
-	if v6 {
+	if v6Action {
 		writeHeader(buf, txID, announceV6ActionID)
 	} else {
 		writeHeader(buf, txID, announceActionID)
@@ -41,7 +42,7 @@ func WriteAnnounce(w io.Writer, txID []byte, resp *bittorrent.AnnounceResponse, 
 	binary.Write(buf, binary.BigEndian, resp.Complete)
 
 	peers := resp.IPv4Peers
-	if v6 {
+	if v6Peers {
 		peers = resp.IPv6Peers
 	}
 


### PR DESCRIPTION
Fixes #391 

Turns out we almost already did this - just the responses were mangled.
Also updated docs to indicate we can do both now.

The "old" opentracker IPv6 way has the advantage of having a usable `ip` field in the announce, to enable IP spoofing.