### PR TITLE
http: explicitly set Content-Type header

### DIFF
--- a/frontend/http/frontend.go
+++ b/frontend/http/frontend.go
@@ -318,6 +318,7 @@ func (f *Frontend) announceRoute(w http.ResponseWriter, r *http.Request, _ httpr
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	err = WriteAnnounceResponse(w, resp)
 	if err != nil {
 		WriteError(w, err)
@@ -375,6 +376,7 @@ func (f *Frontend) scrapeRoute(w http.ResponseWriter, r *http.Request, _ httprou
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	err = WriteScrapeResponse(w, resp)
 	if err != nil {
 		WriteError(w, err)


### PR DESCRIPTION
Since Content-Type is not explicitly set, golang sniffs the responses
and attempts a guess. With announce responses, this usually means it
guesses application/octet-stream.

According to the godoc at
https://golang.org/pkg/net/http/#ResponseWriter

// If WriteHeader has not yet been called, Write calls
// WriteHeader(http.StatusOK) before writing the data. If the Header
// does not contain a Content-Type line, Write adds a Content-Type set
// to the result of passing the initial 512 bytes of written data to
// DetectContentType. Additionally, if the total size of all written
// data is under a few KB and there are no Flush calls, the
// Content-Length header is added automatically.