### PR TITLE
http: allow for customized routes

### DIFF
--- a/bittorrent/params.go
+++ b/bittorrent/params.go
@@ -54,6 +54,22 @@ type QueryParams struct {
 	infoHashes []InfoHash
 }
 
+type routeParamsKey struct{}
+
+// RouteParamsKey is a key for the context of a request that
+// contains the named parameters from the http router
+var RouteParamsKey = routeParamsKey{}
+
+// RouteParam is a type that contains the values from the named parameters
+// on the route
+type RouteParam struct {
+	Key   string
+	Value string
+}
+
+// RouteParams is a collection of RouteParam instances
+type RouteParams []RouteParam
+
 // ParseURLData parses a request URL or UDP URLData as defined in BEP41.
 // It expects a concatenated string of the request's path and query parts as
 // defined in RFC 3986. As both the udp: and http: scheme used by BitTorrent

--- a/bittorrent/params.go
+++ b/bittorrent/params.go
@@ -57,17 +57,17 @@ type QueryParams struct {
 type routeParamsKey struct{}
 
 // RouteParamsKey is a key for the context of a request that
-// contains the named parameters from the http router
+// contains the named parameters from the http router.
 var RouteParamsKey = routeParamsKey{}
 
 // RouteParam is a type that contains the values from the named parameters
-// on the route
+// on the route.
 type RouteParam struct {
 	Key   string
 	Value string
 }
 
-// RouteParams is a collection of RouteParam instances
+// RouteParams is a collection of RouteParam instances.
 type RouteParams []RouteParam
 
 // ParseURLData parses a request URL or UDP URLData as defined in BEP41.

--- a/dist/example_config.yaml
+++ b/dist/example_config.yaml
@@ -41,15 +41,25 @@ chihaya:
     # Disabling this should increase performance/decrease load.
     enable_request_timing: false
 
-    # Whether to listen on /announce.php and /scrape.php in addition to their
-    # non-.php counterparts.
-    # This is an option for compatibility with (very) old clients or otherwise
-    # outdated systems.
-    # This might be useful to retracker.local users, for more information see
-    # http://rutracker.wiki/Оптимизация_обмена_битторрент_траффиком_в_локальных_сетях
-    # and
-    # http://rutracker.wiki/Retracker.local
-    enable_legacy_php_urls: false
+    # An array of routes to listen on for announce requests. This is an option
+    # to support trackers that do not listen for /announce or need to listen
+    # on multiple routes.
+    #
+    # This supports named parameters and catch-all parameters as described at
+    # https://github.com/julienschmidt/httprouter#named-parameters
+    announce_routes:
+      - "/announce"
+      # - "/announce.php"
+
+    # An array of routes to listen on for scrape requests. This is an option
+    # to support trackers that do not listen for /scrape or need to listen
+    # on multiple routes.
+    #
+    # This supports named parameters and catch-all parameters as described at
+    # https://github.com/julienschmidt/httprouter#named-parameters
+    scrape_routes:
+      - "/scrape"
+      # - "/scrape.php"
 
     # When enabled, the IP address used to connect to the tracker will not
     # override the value clients advertise as their IP address.

--- a/dist/travis/config_memory.yaml
+++ b/dist/travis/config_memory.yaml
@@ -16,7 +16,10 @@ chihaya:
     enable_keepalive: false
     idle_timeout: 30s
     enable_request_timing: false
-    enable_legacy_php_urls: false
+    announce_routes:
+      - "/announce"
+    scrape_routes:
+      - "/scrape"
     allow_ip_spoofing: false
     real_ip_header: "x-real-ip"
     max_numwant: 100

--- a/dist/travis/config_redis.yaml
+++ b/dist/travis/config_redis.yaml
@@ -16,7 +16,10 @@ chihaya:
     enable_keepalive: false
     idle_timeout: 30s
     enable_request_timing: false
-    enable_legacy_php_urls: false
+    announce_routes:
+      - "/announce"
+    scrape_routes:
+      - "/scrape"
     allow_ip_spoofing: false
     real_ip_header: "x-real-ip"
     max_numwant: 100


### PR DESCRIPTION
Update to allow arrays of routes to be passed to the http frontend.
This also supports named parameters as permitted by the
router.

To avoid external dependencies in the middleware, a RouteParam and
RouteParams type was added to the bittorrent package.

Note: this eliminates the need for "enable_legacy_php_urls", as
the the additional route could be added to the route array. However,
this may be considered a breaking change.