### PR TITLE
Fixes Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /go/src/github.com/chihaya/chihaya
 COPY . /go/src/github.com/chihaya/chihaya
 
 # Install our golang dependencies and compile our binary.
-RUN CGO_ENABLED=0 go install github.com/chihaya/chihaya/cmd/...
+RUN CGO_ENABLED=0 go install ./cmd/chihaya
 
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
With Go Modules, the current Dockerfile ignores the code that was COPY'd
from the Docker context (and thus always building/installing what was on
GitHub).