### PR TITLE
.github/workflows: only run dependabot CI on PR

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,5 +1,14 @@
 name: CI
-on: [push, pull_request]
+on:
+  # See the documentation for more intricate event dispatch here:
+  # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
+  push:
+    branches:
+    - "!dependabot/*"
+    - "*"
+  pull_request:
+    branches:
+    - "*"
 jobs:
   build:
     name: Build & Lint


### PR DESCRIPTION
Because dependabot creates branches on the origin repository, it triggers a CI run for both "push" and "pull request" unless this patch is applied.