### PR TITLE
Guarantee sorted keys when bencoding Dict (fixes #520)

### DIFF
--- a/frontend/http/bencode/encoder.go
+++ b/frontend/http/bencode/encoder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -181,7 +182,14 @@ func marshalMap(w io.Writer, v map[string]interface{}) error {
 		return err
 	}
 
-	for key, val := range v {
+	var keys []string
+	for key, _ := range v {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		val := v[key]
 		if err := marshalString(w, key); err != nil {
 			return err
 		}


### PR DESCRIPTION
BEP 3 requires dictionaries' keys to be in sorted order.  Since Go's map
traversal is not guaranteed to be in alphabetical order, the keys need
to be copied and sorted before bencoding the key-value pairs.

This fixes #520