### PR TITLE
Proof-of-concept clustering

### DIFF
--- a/cmd/chihaya/config.go
+++ b/cmd/chihaya/config.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/chihaya/chihaya/middleware/varinterval"
 
 	// Imports to register storage drivers.
+	_ "github.com/chihaya/chihaya/storage/cluster"
 	_ "github.com/chihaya/chihaya/storage/memory"
 	_ "github.com/chihaya/chihaya/storage/redis"
 )

--- a/cmd/chihaya/signal_windows.go
+++ b/cmd/chihaya/signal_windows.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"os"
-	"os/signal"
 	"syscall"
 )
 

--- a/dist/example_config.yaml
+++ b/dist/example_config.yaml
@@ -111,7 +111,6 @@ chihaya:
     # The maximum number of infohashes that can be scraped in one request.
     max_scrape_infohashes: 50
 
-
   # This block defines configuration used for the storage of peer data.
   storage:
     name: "memory"
@@ -163,6 +162,44 @@ chihaya:
 
   #     # The timeout for connecting to redis server.
   #     redis_connect_timeout: "15s"
+
+  # This block defines configuration used for cluster storage.
+  # storage:
+  #   name: cluster
+  #   config:
+  #     # The frequency which stale peers are removed.
+  #     # This balances between
+  #     # - collecting garbage more often, potentially using more CPU time, but potentially using less memory (lower value)
+  #     # - collecting garbage less frequently, saving CPU time, but keeping old peers long, thus using more memory (higher value).
+  #     gc_interval: "3m"
+
+  #     # The amount of time until a peer is considered stale.
+  #     # To avoid churn, keep this slightly larger than `announce_interval`
+  #     peer_lifetime: "31m"
+
+  #     # The number of partitions data will be divided into in order to provide a
+  #     # higher degree of parallelism.
+  #     shard_count: 1024
+
+  #     # The interval at which metrics about the number of infohashes and peers
+  #     # are collected and posted to Prometheus.
+  #     prometheus_reporting_interval: "1s"
+
+  #     # The address and port the cluster will be listening to for internal communications.
+  #     bind_addr: "0.0.0.0"
+  #     bind_port: 5000
+
+  #     # The address and port of a node that is already a member of the cluster that will help us join them.
+  #     join_addr: "10.0.0.1"
+  #     join_port: 5000
+
+  #     # The address and port we provide to the to other peers to contact us.
+  #     # This is rarely necessary, perhaps when behind NAT routing and the self IP detection discovery fails.
+  #     advertise_addr: ""
+  #     advertise_port: 5000
+
+  #     # The maximum amount of time waiting for responses from other nodes in the cluster.
+  #     relay_timeout: "5s"
 
   # This block defines configuration used for middleware executed before a
   # response has been returned to a BitTorrent client.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/anacrolix/torrent v1.40.0
 	github.com/go-redsync/redsync/v4 v4.5.0
 	github.com/gomodule/redigo v1.8.8
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/memberlist v0.3.1 // indirect
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,7 @@ github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/arl/statsviz v0.4.0/go.mod h1:+5inUy/dxy11x/KSmicG3ZrEEy0Yr81AFm3dn4QC04M=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
+github.com/armon/go-metrics v0.3.10 h1:FR+drcQStOe+32sYyJYyZ7FIdgoGGBnwLl+flodp8Uo=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -421,6 +422,7 @@ github.com/gomodule/redigo v1.8.8/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs0
 github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -462,6 +464,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
@@ -500,7 +503,9 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-msgpack v0.5.3 h1:zKjpN5BK/P5lMYrLmBHdBULWbJ0XpYR+7NGzqkZzoD4=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
@@ -508,6 +513,7 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
+github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -516,6 +522,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -525,6 +532,8 @@ github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
+github.com/hashicorp/memberlist v0.3.1 h1:MXgUXLqva1QvpVEDQW1IQLG0wivQAtmFlHRQ+1vWZfM=
+github.com/hashicorp/memberlist v0.3.1/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
@@ -629,6 +638,7 @@ github.com/mendsley/gojwk v0.0.0-20141217222730-4d5ec6e58103/go.mod h1:o9YPB5aGP
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
+github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
@@ -830,6 +840,7 @@ github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5P
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
+github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
@@ -1082,6 +1093,7 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/storage/cluster/commands.go
+++ b/storage/cluster/commands.go
@@ -1,0 +1,70 @@
+package cluster
+
+import (
+	"github.com/chihaya/chihaya/bittorrent"
+	"github.com/google/uuid"
+)
+
+const (
+	CmdPutSeeder             uint8 = 1
+	CmdPutLeecher            uint8 = 2
+	CmdDeleteSeeder          uint8 = 3
+	CmdDeleteLeecher         uint8 = 4
+	CmdGraduateLeecher       uint8 = 5
+	CmdAnnouncePeersRequest  uint8 = 6
+	CmdAnnouncePeersResponse uint8 = 7
+	CmdScrapeSwarmRequest    uint8 = 8
+	CmdScrapeSwarmResponse   uint8 = 9
+)
+
+type CmdPutSeederData struct {
+	InfoHash bittorrent.InfoHash
+	Peer     bittorrent.Peer
+}
+
+type CmdPutLeecherData struct {
+	InfoHash bittorrent.InfoHash
+	Peer     bittorrent.Peer
+}
+
+type CmdDeleteSeederData struct {
+	InfoHash bittorrent.InfoHash
+	Peer     bittorrent.Peer
+}
+
+type CmdDeleteLeecherData struct {
+	InfoHash bittorrent.InfoHash
+	Peer     bittorrent.Peer
+}
+
+type CmdGraduateLeecherData struct {
+	InfoHash bittorrent.InfoHash
+	Peer     bittorrent.Peer
+}
+
+type CmdAnnouncePeersRequestData struct {
+	RequestID uuid.UUID
+	InfoHash  bittorrent.InfoHash
+	Announcer bittorrent.Peer
+	NodeName  string
+	Seeder    bool
+	NumWant   int
+}
+
+type CmdAnnouncePeersResponseData struct {
+	RequestID uuid.UUID
+	Error     error
+	Peers     []bittorrent.Peer
+}
+
+type CmdScrapeSwarmRequestData struct {
+	RequestID     uuid.UUID
+	InfoHash      bittorrent.InfoHash
+	NodeName      string
+	AddressFamily bittorrent.AddressFamily
+}
+
+type CmdScrapeSwarmResponseData struct {
+	RequestID uuid.UUID
+	Scrape    bittorrent.Scrape
+}

--- a/storage/cluster/delegate.go
+++ b/storage/cluster/delegate.go
@@ -81,9 +81,7 @@ func (ps *peerStore) NotifyMsg(msg []byte) {
 			return
 		}
 
-		if err := ps.ms.PutSeeder(data.InfoHash, data.Peer); err != nil {
-			log.Error("Failed to put seeder into memory store", log.Err(err))
-		}
+		ps.ms.PutSeeder(data.InfoHash, data.Peer)
 
 	case CmdPutLeecher:
 		data := CmdPutLeecherData{}
@@ -92,9 +90,7 @@ func (ps *peerStore) NotifyMsg(msg []byte) {
 			return
 		}
 
-		if err := ps.ms.PutLeecher(data.InfoHash, data.Peer); err != nil {
-			log.Error("Failed to put leecher into memory store", log.Err(err))
-		}
+		ps.ms.PutLeecher(data.InfoHash, data.Peer)
 
 	case CmdDeleteSeeder:
 		data := CmdDeleteSeederData{}
@@ -103,9 +99,7 @@ func (ps *peerStore) NotifyMsg(msg []byte) {
 			return
 		}
 
-		if err := ps.ms.DeleteSeeder(data.InfoHash, data.Peer); err != nil {
-			log.Error("Failed to delete seeder from memory store", log.Err(err))
-		}
+		ps.ms.DeleteSeeder(data.InfoHash, data.Peer)
 
 	case CmdDeleteLeecher:
 		data := CmdDeleteLeecherData{}
@@ -114,9 +108,7 @@ func (ps *peerStore) NotifyMsg(msg []byte) {
 			return
 		}
 
-		if err := ps.ms.DeleteLeecher(data.InfoHash, data.Peer); err != nil {
-			log.Error("Failed to delete leecher from memory store", log.Err(err))
-		}
+		ps.ms.DeleteLeecher(data.InfoHash, data.Peer)
 
 	case CmdGraduateLeecher:
 		data := CmdGraduateLeecherData{}
@@ -125,9 +117,7 @@ func (ps *peerStore) NotifyMsg(msg []byte) {
 			return
 		}
 
-		if err := ps.ms.GraduateLeecher(data.InfoHash, data.Peer); err != nil {
-			log.Error("Failed to graduate leecher in memory store", log.Err(err))
-		}
+		ps.ms.GraduateLeecher(data.InfoHash, data.Peer)
 
 	case CmdAnnouncePeersRequest:
 		data := CmdAnnouncePeersRequestData{}

--- a/storage/cluster/delegate.go
+++ b/storage/cluster/delegate.go
@@ -26,6 +26,13 @@ func (ps *peerStore) NotifyJoin(n *memberlist.Node) {
 	})
 
 	ps.nodes = nodes
+
+	if ps.nodeName != n.Name {
+		log.Info("A node joined the cluster", log.Fields{
+			"name":  n.Name,
+			"total": len(nodes),
+		})
+	}
 }
 
 func (ps *peerStore) NotifyLeave(n *memberlist.Node) {
@@ -44,6 +51,11 @@ func (ps *peerStore) NotifyLeave(n *memberlist.Node) {
 	})
 
 	ps.nodes = nodes
+
+	log.Info("A node left the cluster", log.Fields{
+		"name":  n.Name,
+		"total": len(nodes),
+	})
 }
 
 func (ps *peerStore) NotifyUpdate(n *memberlist.Node)            {}

--- a/storage/cluster/delegate.go
+++ b/storage/cluster/delegate.go
@@ -1,0 +1,202 @@
+package cluster
+
+import (
+	"bytes"
+	"encoding/gob"
+	"sort"
+
+	"github.com/chihaya/chihaya/bittorrent"
+	"github.com/chihaya/chihaya/pkg/log"
+	"github.com/hashicorp/memberlist"
+)
+
+func (ps *peerStore) NotifyJoin(n *memberlist.Node) {
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
+
+	ps.nodesByName[n.Name] = n
+
+	nodes := make([]*memberlist.Node, 0)
+	for _, v := range ps.nodesByName {
+		nodes = append(nodes, v)
+	}
+
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return nodes[i].Name < nodes[j].Name
+	})
+
+	ps.nodes = nodes
+}
+
+func (ps *peerStore) NotifyLeave(n *memberlist.Node) {
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
+
+	delete(ps.nodesByName, n.Name)
+
+	nodes := make([]*memberlist.Node, 0)
+	for _, v := range ps.nodesByName {
+		nodes = append(nodes, v)
+	}
+
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return nodes[i].Name < nodes[j].Name
+	})
+
+	ps.nodes = nodes
+}
+
+func (ps *peerStore) NotifyUpdate(n *memberlist.Node)            {}
+func (ps *peerStore) NodeMeta(limit int) []byte                  { return nil }
+func (ps *peerStore) GetBroadcasts(overhead, limit int) [][]byte { return nil }
+func (ps *peerStore) LocalState(join bool) []byte                { return nil }
+func (ps *peerStore) MergeRemoteState(buf []byte, join bool)     {}
+
+func (ps *peerStore) NotifyMsg(msg []byte) {
+	decoder := gob.NewDecoder(bytes.NewReader(msg))
+	cmd := uint8(0)
+
+	if err := decoder.Decode(&cmd); err != nil {
+		log.Error("Failed to decode notification", log.Err(err))
+		return
+	}
+
+	switch cmd {
+	case CmdPutSeeder:
+		data := CmdPutSeederData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdPutSeeder", log.Err(err))
+			return
+		}
+
+		if err := ps.ms.PutSeeder(data.InfoHash, data.Peer); err != nil {
+			log.Error("Failed to put seeder into memory store", log.Err(err))
+		}
+
+	case CmdPutLeecher:
+		data := CmdPutLeecherData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdPutLeecher", log.Err(err))
+			return
+		}
+
+		if err := ps.ms.PutLeecher(data.InfoHash, data.Peer); err != nil {
+			log.Error("Failed to put leecher into memory store", log.Err(err))
+		}
+
+	case CmdDeleteSeeder:
+		data := CmdDeleteSeederData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdDeleteSeeder", log.Err(err))
+			return
+		}
+
+		if err := ps.ms.DeleteSeeder(data.InfoHash, data.Peer); err != nil {
+			log.Error("Failed to delete seeder from memory store", log.Err(err))
+		}
+
+	case CmdDeleteLeecher:
+		data := CmdDeleteLeecherData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdDeleteLeecher", log.Err(err))
+			return
+		}
+
+		if err := ps.ms.DeleteLeecher(data.InfoHash, data.Peer); err != nil {
+			log.Error("Failed to delete leecher from memory store", log.Err(err))
+		}
+
+	case CmdGraduateLeecher:
+		data := CmdGraduateLeecherData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdGraduateLeecher", log.Err(err))
+			return
+		}
+
+		if err := ps.ms.GraduateLeecher(data.InfoHash, data.Peer); err != nil {
+			log.Error("Failed to graduate leecher in memory store", log.Err(err))
+		}
+
+	case CmdAnnouncePeersRequest:
+		data := CmdAnnouncePeersRequestData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdAnnouncePeersRequest", log.Err(err))
+			return
+		}
+
+		buffer := bytes.Buffer{}
+		encoder := gob.NewEncoder(&buffer)
+		peers, err := ps.ms.AnnouncePeers(data.InfoHash, data.Seeder, data.NumWant, data.Announcer)
+
+		encoder.Encode(CmdAnnouncePeersResponse)
+		encoder.Encode(CmdAnnouncePeersResponseData{
+			RequestID: data.RequestID,
+			Error:     err,
+			Peers:     peers,
+		})
+
+		ps.mutex.RLock()
+		node := ps.nodesByName[data.NodeName]
+		ps.mutex.RUnlock()
+
+		ps.cluster.SendReliable(node, buffer.Bytes())
+
+	case CmdAnnouncePeersResponse:
+		data := CmdAnnouncePeersResponseData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdAnnouncePeersResponse", log.Err(err))
+			return
+		}
+
+		c, ok := ps.pending.Load(data.RequestID)
+		if !ok {
+			log.Error("Request ID isn't in the pending map")
+			return
+		}
+
+		c.(chan []bittorrent.Peer) <- data.Peers
+
+	case CmdScrapeSwarmRequest:
+		data := CmdScrapeSwarmRequestData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdScrapeSwarmRequest", log.Err(err))
+			return
+		}
+
+		buffer := bytes.Buffer{}
+		encoder := gob.NewEncoder(&buffer)
+		scrape := ps.ms.ScrapeSwarm(data.InfoHash, data.AddressFamily)
+
+		encoder.Encode(CmdScrapeSwarmResponse)
+		encoder.Encode(CmdScrapeSwarmResponseData{
+			RequestID: data.RequestID,
+			Scrape:    scrape,
+		})
+
+		ps.mutex.RLock()
+		node := ps.nodesByName[data.NodeName]
+		ps.mutex.RUnlock()
+
+		ps.cluster.SendReliable(node, buffer.Bytes())
+
+	case CmdScrapeSwarmResponse:
+		data := CmdScrapeSwarmResponseData{}
+		if err := decoder.Decode(&data); err != nil {
+			log.Error("Failed to decode CmdScrapeSwarmResponse", log.Err(err))
+			return
+		}
+
+		c, ok := ps.pending.Load(data.RequestID)
+		if !ok {
+			log.Error("Request ID isn't in the pending map")
+			return
+		}
+
+		c.(chan bittorrent.Scrape) <- data.Scrape
+
+	default:
+		log.Error("Unknown notification command", log.Fields{
+			"cmd": cmd,
+		})
+	}
+}

--- a/storage/cluster/peer_store.go
+++ b/storage/cluster/peer_store.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"io/ioutil"
+	golog "log"
 	"math"
 	"sync"
 	"time"
@@ -235,6 +237,7 @@ func New(provided Config) (storage.PeerStore, error) {
 	clusterCfg.AdvertisePort = cfg.AdvertisePort
 	clusterCfg.Delegate = ps
 	clusterCfg.Events = ps
+	clusterCfg.Logger = golog.New(ioutil.Discard, "", 0)
 
 	cluster, err := memberlist.Create(clusterCfg)
 

--- a/storage/cluster/peer_store.go
+++ b/storage/cluster/peer_store.go
@@ -1,0 +1,597 @@
+// Package memory implements the storage interface for a Chihaya
+// BitTorrent tracker keeping peer data in memory.
+package memory
+
+import (
+	"encoding/binary"
+	"math"
+	"net"
+	"runtime"
+	"sync"
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/chihaya/chihaya/bittorrent"
+	"github.com/chihaya/chihaya/pkg/log"
+	"github.com/chihaya/chihaya/pkg/stop"
+	"github.com/chihaya/chihaya/pkg/timecache"
+	"github.com/chihaya/chihaya/storage"
+)
+
+// Name is the name by which this peer store is registered with Chihaya.
+const Name = "memory"
+
+// Default config constants.
+const (
+	defaultShardCount                  = 1024
+	defaultPrometheusReportingInterval = time.Second * 1
+	defaultGarbageCollectionInterval   = time.Minute * 3
+	defaultPeerLifetime                = time.Minute * 30
+)
+
+func init() {
+	// Register the storage driver.
+	storage.RegisterDriver(Name, driver{})
+}
+
+type driver struct{}
+
+func (d driver) NewPeerStore(icfg interface{}) (storage.PeerStore, error) {
+	// Marshal the config back into bytes.
+	bytes, err := yaml.Marshal(icfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the bytes into the proper config type.
+	var cfg Config
+	err = yaml.Unmarshal(bytes, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(cfg)
+}
+
+// Config holds the configuration of a memory PeerStore.
+type Config struct {
+	GarbageCollectionInterval   time.Duration `yaml:"gc_interval"`
+	PrometheusReportingInterval time.Duration `yaml:"prometheus_reporting_interval"`
+	PeerLifetime                time.Duration `yaml:"peer_lifetime"`
+	ShardCount                  int           `yaml:"shard_count"`
+}
+
+// LogFields renders the current config as a set of Logrus fields.
+func (cfg Config) LogFields() log.Fields {
+	return log.Fields{
+		"name":               Name,
+		"gcInterval":         cfg.GarbageCollectionInterval,
+		"promReportInterval": cfg.PrometheusReportingInterval,
+		"peerLifetime":       cfg.PeerLifetime,
+		"shardCount":         cfg.ShardCount,
+	}
+}
+
+// Validate sanity checks values set in a config and returns a new config with
+// default values replacing anything that is invalid.
+//
+// This function warns to the logger when a value is changed.
+func (cfg Config) Validate() Config {
+	validcfg := cfg
+
+	if cfg.ShardCount <= 0 || cfg.ShardCount > (math.MaxInt/2) {
+		validcfg.ShardCount = defaultShardCount
+		log.Warn("falling back to default configuration", log.Fields{
+			"name":     Name + ".ShardCount",
+			"provided": cfg.ShardCount,
+			"default":  validcfg.ShardCount,
+		})
+	}
+
+	if cfg.GarbageCollectionInterval <= 0 {
+		validcfg.GarbageCollectionInterval = defaultGarbageCollectionInterval
+		log.Warn("falling back to default configuration", log.Fields{
+			"name":     Name + ".GarbageCollectionInterval",
+			"provided": cfg.GarbageCollectionInterval,
+			"default":  validcfg.GarbageCollectionInterval,
+		})
+	}
+
+	if cfg.PrometheusReportingInterval <= 0 {
+		validcfg.PrometheusReportingInterval = defaultPrometheusReportingInterval
+		log.Warn("falling back to default configuration", log.Fields{
+			"name":     Name + ".PrometheusReportingInterval",
+			"provided": cfg.PrometheusReportingInterval,
+			"default":  validcfg.PrometheusReportingInterval,
+		})
+	}
+
+	if cfg.PeerLifetime <= 0 {
+		validcfg.PeerLifetime = defaultPeerLifetime
+		log.Warn("falling back to default configuration", log.Fields{
+			"name":     Name + ".PeerLifetime",
+			"provided": cfg.PeerLifetime,
+			"default":  validcfg.PeerLifetime,
+		})
+	}
+
+	return validcfg
+}
+
+// New creates a new PeerStore backed by memory.
+func New(provided Config) (storage.PeerStore, error) {
+	cfg := provided.Validate()
+	ps := &peerStore{
+		cfg:    cfg,
+		shards: make([]*peerShard, cfg.ShardCount*2),
+		closed: make(chan struct{}),
+	}
+
+	for i := 0; i < cfg.ShardCount*2; i++ {
+		ps.shards[i] = &peerShard{swarms: make(map[bittorrent.InfoHash]swarm)}
+	}
+
+	// Start a goroutine for garbage collection.
+	ps.wg.Add(1)
+	go func() {
+		defer ps.wg.Done()
+		for {
+			select {
+			case <-ps.closed:
+				return
+			case <-time.After(cfg.GarbageCollectionInterval):
+				before := time.Now().Add(-cfg.PeerLifetime)
+				log.Debug("storage: purging peers with no announces since", log.Fields{"before": before})
+				_ = ps.collectGarbage(before)
+			}
+		}
+	}()
+
+	// Start a goroutine for reporting statistics to Prometheus.
+	ps.wg.Add(1)
+	go func() {
+		defer ps.wg.Done()
+		t := time.NewTicker(cfg.PrometheusReportingInterval)
+		for {
+			select {
+			case <-ps.closed:
+				t.Stop()
+				return
+			case <-t.C:
+				before := time.Now()
+				ps.populateProm()
+				log.Debug("storage: populateProm() finished", log.Fields{"timeTaken": time.Since(before)})
+			}
+		}
+	}()
+
+	return ps, nil
+}
+
+type serializedPeer string
+
+func newPeerKey(p bittorrent.Peer) serializedPeer {
+	b := make([]byte, 20+2+len(p.IP.IP))
+	copy(b[:20], p.ID[:])
+	binary.BigEndian.PutUint16(b[20:22], p.Port)
+	copy(b[22:], p.IP.IP)
+
+	return serializedPeer(b)
+}
+
+func decodePeerKey(pk serializedPeer) bittorrent.Peer {
+	peer := bittorrent.Peer{
+		ID:   bittorrent.PeerIDFromString(string(pk[:20])),
+		Port: binary.BigEndian.Uint16([]byte(pk[20:22])),
+		IP:   bittorrent.IP{IP: net.IP(pk[22:])},
+	}
+
+	if ip := peer.IP.To4(); ip != nil {
+		peer.IP.IP = ip
+		peer.IP.AddressFamily = bittorrent.IPv4
+	} else if len(peer.IP.IP) == net.IPv6len { // implies toReturn.IP.To4() == nil
+		peer.IP.AddressFamily = bittorrent.IPv6
+	} else {
+		panic("IP is neither v4 nor v6")
+	}
+
+	return peer
+}
+
+type peerShard struct {
+	swarms      map[bittorrent.InfoHash]swarm
+	numSeeders  uint64
+	numLeechers uint64
+	sync.RWMutex
+}
+
+type swarm struct {
+	// map serialized peer to mtime
+	seeders  map[serializedPeer]int64
+	leechers map[serializedPeer]int64
+}
+
+type peerStore struct {
+	cfg    Config
+	shards []*peerShard
+
+	closed chan struct{}
+	wg     sync.WaitGroup
+}
+
+var _ storage.PeerStore = &peerStore{}
+
+// populateProm aggregates metrics over all shards and then posts them to
+// prometheus.
+func (ps *peerStore) populateProm() {
+	var numInfohashes, numSeeders, numLeechers uint64
+
+	for _, s := range ps.shards {
+		s.RLock()
+		numInfohashes += uint64(len(s.swarms))
+		numSeeders += s.numSeeders
+		numLeechers += s.numLeechers
+		s.RUnlock()
+	}
+
+	storage.PromInfohashesCount.Set(float64(numInfohashes))
+	storage.PromSeedersCount.Set(float64(numSeeders))
+	storage.PromLeechersCount.Set(float64(numLeechers))
+}
+
+// recordGCDuration records the duration of a GC sweep.
+func recordGCDuration(duration time.Duration) {
+	storage.PromGCDurationMilliseconds.Observe(float64(duration.Nanoseconds()) / float64(time.Millisecond))
+}
+
+func (ps *peerStore) getClock() int64 {
+	return timecache.NowUnixNano()
+}
+
+func (ps *peerStore) shardIndex(infoHash bittorrent.InfoHash, af bittorrent.AddressFamily) uint32 {
+	// There are twice the amount of shards specified by the user, the first
+	// half is dedicated to IPv4 swarms and the second half is dedicated to
+	// IPv6 swarms.
+	idx := binary.BigEndian.Uint32(infoHash[:4]) % (uint32(len(ps.shards)) / 2)
+	if af == bittorrent.IPv6 {
+		idx += uint32(len(ps.shards) / 2)
+	}
+	return idx
+}
+
+func (ps *peerStore) PutSeeder(ih bittorrent.InfoHash, p bittorrent.Peer) error {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	pk := newPeerKey(p)
+
+	shard := ps.shards[ps.shardIndex(ih, p.IP.AddressFamily)]
+	shard.Lock()
+
+	if _, ok := shard.swarms[ih]; !ok {
+		shard.swarms[ih] = swarm{
+			seeders:  make(map[serializedPeer]int64),
+			leechers: make(map[serializedPeer]int64),
+		}
+	}
+
+	// If this peer isn't already a seeder, update the stats for the swarm.
+	if _, ok := shard.swarms[ih].seeders[pk]; !ok {
+		shard.numSeeders++
+	}
+
+	// Update the peer in the swarm.
+	shard.swarms[ih].seeders[pk] = ps.getClock()
+
+	shard.Unlock()
+	return nil
+}
+
+func (ps *peerStore) DeleteSeeder(ih bittorrent.InfoHash, p bittorrent.Peer) error {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	pk := newPeerKey(p)
+
+	shard := ps.shards[ps.shardIndex(ih, p.IP.AddressFamily)]
+	shard.Lock()
+
+	if _, ok := shard.swarms[ih]; !ok {
+		shard.Unlock()
+		return storage.ErrResourceDoesNotExist
+	}
+
+	if _, ok := shard.swarms[ih].seeders[pk]; !ok {
+		shard.Unlock()
+		return storage.ErrResourceDoesNotExist
+	}
+
+	shard.numSeeders--
+	delete(shard.swarms[ih].seeders, pk)
+
+	if len(shard.swarms[ih].seeders)|len(shard.swarms[ih].leechers) == 0 {
+		delete(shard.swarms, ih)
+	}
+
+	shard.Unlock()
+	return nil
+}
+
+func (ps *peerStore) PutLeecher(ih bittorrent.InfoHash, p bittorrent.Peer) error {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	pk := newPeerKey(p)
+
+	shard := ps.shards[ps.shardIndex(ih, p.IP.AddressFamily)]
+	shard.Lock()
+
+	if _, ok := shard.swarms[ih]; !ok {
+		shard.swarms[ih] = swarm{
+			seeders:  make(map[serializedPeer]int64),
+			leechers: make(map[serializedPeer]int64),
+		}
+	}
+
+	// If this peer isn't already a leecher, update the stats for the swarm.
+	if _, ok := shard.swarms[ih].leechers[pk]; !ok {
+		shard.numLeechers++
+	}
+
+	// Update the peer in the swarm.
+	shard.swarms[ih].leechers[pk] = ps.getClock()
+
+	shard.Unlock()
+	return nil
+}
+
+func (ps *peerStore) DeleteLeecher(ih bittorrent.InfoHash, p bittorrent.Peer) error {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	pk := newPeerKey(p)
+
+	shard := ps.shards[ps.shardIndex(ih, p.IP.AddressFamily)]
+	shard.Lock()
+
+	if _, ok := shard.swarms[ih]; !ok {
+		shard.Unlock()
+		return storage.ErrResourceDoesNotExist
+	}
+
+	if _, ok := shard.swarms[ih].leechers[pk]; !ok {
+		shard.Unlock()
+		return storage.ErrResourceDoesNotExist
+	}
+
+	shard.numLeechers--
+	delete(shard.swarms[ih].leechers, pk)
+
+	if len(shard.swarms[ih].seeders)|len(shard.swarms[ih].leechers) == 0 {
+		delete(shard.swarms, ih)
+	}
+
+	shard.Unlock()
+	return nil
+}
+
+func (ps *peerStore) GraduateLeecher(ih bittorrent.InfoHash, p bittorrent.Peer) error {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	pk := newPeerKey(p)
+
+	shard := ps.shards[ps.shardIndex(ih, p.IP.AddressFamily)]
+	shard.Lock()
+
+	if _, ok := shard.swarms[ih]; !ok {
+		shard.swarms[ih] = swarm{
+			seeders:  make(map[serializedPeer]int64),
+			leechers: make(map[serializedPeer]int64),
+		}
+	}
+
+	// If this peer is a leecher, update the stats for the swarm and remove them.
+	if _, ok := shard.swarms[ih].leechers[pk]; ok {
+		shard.numLeechers--
+		delete(shard.swarms[ih].leechers, pk)
+	}
+
+	// If this peer isn't already a seeder, update the stats for the swarm.
+	if _, ok := shard.swarms[ih].seeders[pk]; !ok {
+		shard.numSeeders++
+	}
+
+	// Update the peer in the swarm.
+	shard.swarms[ih].seeders[pk] = ps.getClock()
+
+	shard.Unlock()
+	return nil
+}
+
+func (ps *peerStore) AnnouncePeers(ih bittorrent.InfoHash, seeder bool, numWant int, announcer bittorrent.Peer) (peers []bittorrent.Peer, err error) {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	shard := ps.shards[ps.shardIndex(ih, announcer.IP.AddressFamily)]
+	shard.RLock()
+
+	if _, ok := shard.swarms[ih]; !ok {
+		shard.RUnlock()
+		return nil, storage.ErrResourceDoesNotExist
+	}
+
+	if seeder {
+		// Append leechers as possible.
+		leechers := shard.swarms[ih].leechers
+		for pk := range leechers {
+			if numWant == 0 {
+				break
+			}
+
+			peers = append(peers, decodePeerKey(pk))
+			numWant--
+		}
+	} else {
+		// Append as many seeders as possible.
+		seeders := shard.swarms[ih].seeders
+		for pk := range seeders {
+			if numWant == 0 {
+				break
+			}
+
+			peers = append(peers, decodePeerKey(pk))
+			numWant--
+		}
+
+		// Append leechers until we reach numWant.
+		if numWant > 0 {
+			leechers := shard.swarms[ih].leechers
+			announcerPK := newPeerKey(announcer)
+			for pk := range leechers {
+				if pk == announcerPK {
+					continue
+				}
+
+				if numWant == 0 {
+					break
+				}
+
+				peers = append(peers, decodePeerKey(pk))
+				numWant--
+			}
+		}
+	}
+
+	shard.RUnlock()
+	return
+}
+
+func (ps *peerStore) ScrapeSwarm(ih bittorrent.InfoHash, addressFamily bittorrent.AddressFamily) (resp bittorrent.Scrape) {
+	select {
+	case <-ps.closed:
+		panic("attempted to interact with stopped memory store")
+	default:
+	}
+
+	resp.InfoHash = ih
+	shard := ps.shards[ps.shardIndex(ih, addressFamily)]
+	shard.RLock()
+
+	swarm, ok := shard.swarms[ih]
+	if !ok {
+		shard.RUnlock()
+		return
+	}
+
+	resp.Incomplete = uint32(len(swarm.leechers))
+	resp.Complete = uint32(len(swarm.seeders))
+	shard.RUnlock()
+
+	return
+}
+
+// collectGarbage deletes all Peers from the PeerStore which are older than the
+// cutoff time.
+//
+// This function must be able to execute while other methods on this interface
+// are being executed in parallel.
+func (ps *peerStore) collectGarbage(cutoff time.Time) error {
+	select {
+	case <-ps.closed:
+		return nil
+	default:
+	}
+
+	cutoffUnix := cutoff.UnixNano()
+	start := time.Now()
+
+	for _, shard := range ps.shards {
+		shard.RLock()
+		var infohashes []bittorrent.InfoHash
+		for ih := range shard.swarms {
+			infohashes = append(infohashes, ih)
+		}
+		shard.RUnlock()
+		runtime.Gosched()
+
+		for _, ih := range infohashes {
+			shard.Lock()
+
+			if _, stillExists := shard.swarms[ih]; !stillExists {
+				shard.Unlock()
+				runtime.Gosched()
+				continue
+			}
+
+			for pk, mtime := range shard.swarms[ih].leechers {
+				if mtime <= cutoffUnix {
+					shard.numLeechers--
+					delete(shard.swarms[ih].leechers, pk)
+				}
+			}
+
+			for pk, mtime := range shard.swarms[ih].seeders {
+				if mtime <= cutoffUnix {
+					shard.numSeeders--
+					delete(shard.swarms[ih].seeders, pk)
+				}
+			}
+
+			if len(shard.swarms[ih].seeders)|len(shard.swarms[ih].leechers) == 0 {
+				delete(shard.swarms, ih)
+			}
+
+			shard.Unlock()
+			runtime.Gosched()
+		}
+
+		runtime.Gosched()
+	}
+
+	recordGCDuration(time.Since(start))
+
+	return nil
+}
+
+func (ps *peerStore) Stop() stop.Result {
+	c := make(stop.Channel)
+	go func() {
+		close(ps.closed)
+		ps.wg.Wait()
+
+		// Explicitly deallocate our storage.
+		shards := make([]*peerShard, len(ps.shards))
+		for i := 0; i < len(ps.shards); i++ {
+			shards[i] = &peerShard{swarms: make(map[bittorrent.InfoHash]swarm)}
+		}
+		ps.shards = shards
+
+		c.Done()
+	}()
+
+	return c.Result()
+}
+
+func (ps *peerStore) LogFields() log.Fields {
+	return ps.cfg.LogFields()
+}

--- a/storage/cluster/peer_store_test.go
+++ b/storage/cluster/peer_store_test.go
@@ -1,0 +1,51 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	s "github.com/chihaya/chihaya/storage"
+)
+
+func createNew() s.PeerStore {
+	ps, err := New(Config{
+		ShardCount:                  1024,
+		GarbageCollectionInterval:   10 * time.Minute,
+		PrometheusReportingInterval: 10 * time.Minute,
+		PeerLifetime:                30 * time.Minute,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return ps
+}
+
+func TestPeerStore(t *testing.T) { s.TestPeerStore(t, createNew()) }
+
+func BenchmarkNop(b *testing.B)                        { s.Nop(b, createNew()) }
+func BenchmarkPut(b *testing.B)                        { s.Put(b, createNew()) }
+func BenchmarkPut1k(b *testing.B)                      { s.Put1k(b, createNew()) }
+func BenchmarkPut1kInfohash(b *testing.B)              { s.Put1kInfohash(b, createNew()) }
+func BenchmarkPut1kInfohash1k(b *testing.B)            { s.Put1kInfohash1k(b, createNew()) }
+func BenchmarkPutDelete(b *testing.B)                  { s.PutDelete(b, createNew()) }
+func BenchmarkPutDelete1k(b *testing.B)                { s.PutDelete1k(b, createNew()) }
+func BenchmarkPutDelete1kInfohash(b *testing.B)        { s.PutDelete1kInfohash(b, createNew()) }
+func BenchmarkPutDelete1kInfohash1k(b *testing.B)      { s.PutDelete1kInfohash1k(b, createNew()) }
+func BenchmarkDeleteNonexist(b *testing.B)             { s.DeleteNonexist(b, createNew()) }
+func BenchmarkDeleteNonexist1k(b *testing.B)           { s.DeleteNonexist1k(b, createNew()) }
+func BenchmarkDeleteNonexist1kInfohash(b *testing.B)   { s.DeleteNonexist1kInfohash(b, createNew()) }
+func BenchmarkDeleteNonexist1kInfohash1k(b *testing.B) { s.DeleteNonexist1kInfohash1k(b, createNew()) }
+func BenchmarkPutGradDelete(b *testing.B)              { s.PutGradDelete(b, createNew()) }
+func BenchmarkPutGradDelete1k(b *testing.B)            { s.PutGradDelete1k(b, createNew()) }
+func BenchmarkPutGradDelete1kInfohash(b *testing.B)    { s.PutGradDelete1kInfohash(b, createNew()) }
+func BenchmarkPutGradDelete1kInfohash1k(b *testing.B)  { s.PutGradDelete1kInfohash1k(b, createNew()) }
+func BenchmarkGradNonexist(b *testing.B)               { s.GradNonexist(b, createNew()) }
+func BenchmarkGradNonexist1k(b *testing.B)             { s.GradNonexist1k(b, createNew()) }
+func BenchmarkGradNonexist1kInfohash(b *testing.B)     { s.GradNonexist1kInfohash(b, createNew()) }
+func BenchmarkGradNonexist1kInfohash1k(b *testing.B)   { s.GradNonexist1kInfohash1k(b, createNew()) }
+func BenchmarkAnnounceLeecher(b *testing.B)            { s.AnnounceLeecher(b, createNew()) }
+func BenchmarkAnnounceLeecher1kInfohash(b *testing.B)  { s.AnnounceLeecher1kInfohash(b, createNew()) }
+func BenchmarkAnnounceSeeder(b *testing.B)             { s.AnnounceSeeder(b, createNew()) }
+func BenchmarkAnnounceSeeder1kInfohash(b *testing.B)   { s.AnnounceSeeder1kInfohash(b, createNew()) }
+func BenchmarkScrapeSwarm(b *testing.B)                { s.ScrapeSwarm(b, createNew()) }
+func BenchmarkScrapeSwarm1kInfohash(b *testing.B)      { s.ScrapeSwarm1kInfohash(b, createNew()) }

--- a/storage/cluster/peer_store_test.go
+++ b/storage/cluster/peer_store_test.go
@@ -1,4 +1,4 @@
-package memory
+package cluster
 
 import (
 	"testing"


### PR DESCRIPTION
## What

This PR adds the ability to link together multiple chihaya nodes to form a cluster, splitting the workload of servicing the requests amongst themselves.

## How
 
Each node runs its own swarm using [memory storage](https://github.com/chihaya/chihaya/tree/main/storage/memory) and the incoming requests are routed to specific nodes in a stable manner based on the torrent's infohash and the amount of nodes.

## High-availability

There isn't a mechanism to ensure that the data is available on other nodes. If a node leaves the cluster, its data goes away with it. Considering that peers have to re-announce themselves periodically, this is only a minor nuisance sometimes waiting longer to obtain peers.

## Scaling

Adding or removing nodes to the cluster directly affects the partitioning of the infohashes. The addition of 1 node to a 5 nodes cluster would cause a 20% disruption to all nodes, where some of the requests originally meant for them are now being serviced by a different node, which because it just joined, wont have much data to provide for a little while.

For all these reasons, it's preferable if the cluster doesn't scale too frequently.

## Configuration

The configuration provides the same fields that the memory storage does, plus new ones.

```
  # This block defines configuration used for cluster storage.
  # storage:
  #   name: cluster
  #   config:
  #     # The frequency which stale peers are removed.
  #     # This balances between
  #     # - collecting garbage more often, potentially using more CPU time, but potentially using less memory (lower value)
  #     # - collecting garbage less frequently, saving CPU time, but keeping old peers long, thus using more memory (higher value).
  #     gc_interval: "3m"

  #     # The amount of time until a peer is considered stale.
  #     # To avoid churn, keep this slightly larger than `announce_interval`
  #     peer_lifetime: "31m"

  #     # The number of partitions data will be divided into in order to provide a
  #     # higher degree of parallelism.
  #     shard_count: 1024

  #     # The interval at which metrics about the number of infohashes and peers
  #     # are collected and posted to Prometheus.
  #     prometheus_reporting_interval: "1s"

  #     # The address and port the cluster will be listening to for internal communications.
  #     bind_addr: "0.0.0.0"
  #     bind_port: 5000

  #     # The address and port of a node that is already a member of the cluster that will help us join them.
  #     join_addr: "10.0.0.1"
  #     join_port: 5000

  #     # The address and port we provide to the to other peers to contact us.
  #     # This is rarely necessary, perhaps when behind NAT routing and the self IP detection discovery fails.
  #     advertise_addr: ""
  #     advertise_port: 5000

  #     # The maximum amount of time waiting for responses from other nodes in the cluster.
  #     relay_timeout: "5s"
```

Nodes form an overlay network and are able to route packets amongst themselves to work around NAT firewalls and other impediments. I personally use the Kubernetes DNS `tracker.namespace.svc.cluster.local` as the join address, all it takes is one known node to join the cluster.

# Performance

This is still incapable of running my tracker past 20% of the load, so I'm still investigating what's wrong.

Current metrics to give an idea of what 100% would mean:

![153891872-e54e8dab-4eed-445b-8fe8-1f05dfefcee4](https://user-images.githubusercontent.com/246380/154727548-243cf630-b0b6-4f3a-b56b-42b979a22363.png)