### PR TITLE
Remove unused import 'os/signal' for windows

### DIFF
--- a/cmd/chihaya/signal_windows.go
+++ b/cmd/chihaya/signal_windows.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"os"
-	"os/signal"
 	"syscall"
 )
 


### PR DESCRIPTION
Single line change, similar as in https://github.com/chihaya/chihaya/commit/129aac23

Unit tests passed on my Windows machine:

```
PS C:\Users\xxx\chihaya> go test $(go list ./...)       
ok      github.com/chihaya/chihaya/bittorrent   0.134s
?       github.com/chihaya/chihaya/cmd/chihaya  [no test files]
?       github.com/chihaya/chihaya/frontend     [no test files]
ok      github.com/chihaya/chihaya/frontend/http        0.091s
ok      github.com/chihaya/chihaya/frontend/http/bencode        0.057s
ok      github.com/chihaya/chihaya/middleware   0.092s [no tests to run]
?       github.com/chihaya/chihaya/middleware/jwt       [no test files]
ok      github.com/chihaya/chihaya/middleware/pkg/random        0.086s
ok      github.com/chihaya/chihaya/middleware/torrentapproval   0.101s
ok      github.com/chihaya/chihaya/middleware/varinterval       0.103s
?       github.com/chihaya/chihaya/pkg/log      [no test files]
?       github.com/chihaya/chihaya/pkg/metrics  [no test files]
?       github.com/chihaya/chihaya/pkg/stop     [no test files]
ok      github.com/chihaya/chihaya/pkg/timecache        0.094s
?       github.com/chihaya/chihaya/storage      [no test files]
ok      github.com/chihaya/chihaya/storage/memory       0.090s
ok      github.com/chihaya/chihaya/storage/redis        0.109s
PS C:\Users\xxx\chihaya> go version
go version go1.18 windows/amd64
```