### PR TITLE
ci: fix lint, add docs

### DIFF
--- a/cmd/chihaya/main.go
+++ b/cmd/chihaya/main.go
@@ -1,3 +1,4 @@
+// Package main provides argument parsing and execution logic for the command line tool.
 package main
 
 import (

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -1,3 +1,5 @@
+// Package frontend provides implementations and abstractions for tracker logic,
+// parsing and request handling over multiple protocols, such as UDP and HTTP.
 package frontend
 
 import (

--- a/frontend/udp/bytepool/bytepool.go
+++ b/frontend/udp/bytepool/bytepool.go
@@ -1,3 +1,5 @@
+// Package bytepool implements an optimization for byte slice allocations
+// by caching those slices for later reuse.
 package bytepool
 
 import "sync"

--- a/middleware/varinterval/varinterval.go
+++ b/middleware/varinterval/varinterval.go
@@ -1,3 +1,6 @@
+// Package varinterval provides a middleware implementation that handles
+// announcement intervals according to configured ranges,
+// giving different values for each peer so they don't re-announce at the same time.
 package varinterval
 
 import (

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -44,8 +44,9 @@ func NewServer(addr string) *Server {
 
 	s := &Server{
 		srv: &http.Server{
-			Addr:    addr,
-			Handler: mux,
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 60,
 		},
 	}
 

--- a/storage/redis/peer_store.go
+++ b/storage/redis/peer_store.go
@@ -2,25 +2,25 @@
 // BitTorrent tracker keeping peer data in redis with hash.
 // There two categories of hash:
 //
-// - IPv{4,6}_{L,S}_infohash
-//	To save peers that hold the infohash, used for fast searching,
-//  deleting, and timeout handling
+//   - IPv{4,6}_{L,S}_infohash
+//     To save peers that hold the infohash, used for fast searching,
+//     deleting, and timeout handling
 //
-// - IPv{4,6}
-//  To save all the infohashes, used for garbage collection,
-//	metrics aggregation and leecher graduation
+//   - IPv{4,6}
+//     To save all the infohashes, used for garbage collection,
+//     metrics aggregation and leecher graduation
 //
 // Tree keys are used to record the count of swarms, seeders
 // and leechers for each group (IPv4, IPv6).
 //
-// - IPv{4,6}_infohash_count
-//	To record the number of infohashes.
+//   - IPv{4,6}_infohash_count
+//     To record the number of infohashes.
 //
-// - IPv{4,6}_S_count
-//	To record the number of seeders.
+//   - IPv{4,6}_S_count
+//     To record the number of seeders.
 //
-// - IPv{4,6}_L_count
-//	To record the number of leechers.
+//   - IPv{4,6}_L_count
+//     To record the number of leechers.
 package redis
 
 import (
@@ -667,45 +667,45 @@ func (ps *peerStore) ScrapeSwarm(ih bittorrent.InfoHash, af bittorrent.AddressFa
 // This function must be able to execute while other methods on this interface
 // are being executed in parallel.
 //
-// - The Delete(Seeder|Leecher) and GraduateLeecher methods never delete an
-//	 infohash key from an addressFamily hash. They also never decrement the
-//	 infohash counter.
-// - The Put(Seeder|Leecher) and GraduateLeecher methods only ever add infohash
-//	 keys to addressFamily hashes and increment the infohash counter.
-// - The only method that deletes from the addressFamily hashes is
-//	 collectGarbage, which also decrements the counters. That means that,
-//	 even if a Delete(Seeder|Leecher) call removes the last peer from a swarm,
-//	 the infohash counter is not changed and the infohash is left in the
-//	 addressFamily hash until it will be cleaned up by collectGarbage.
-// - collectGarbage must run regularly.
-// - A WATCH ... MULTI ... EXEC block fails, if between the WATCH and the 'EXEC'
-// 	 any of the watched keys have changed. The location of the 'MULTI' doesn't
-//	 matter.
+//   - The Delete(Seeder|Leecher) and GraduateLeecher methods never delete an
+//     infohash key from an addressFamily hash. They also never decrement the
+//     infohash counter.
+//   - The Put(Seeder|Leecher) and GraduateLeecher methods only ever add infohash
+//     keys to addressFamily hashes and increment the infohash counter.
+//   - The only method that deletes from the addressFamily hashes is
+//     collectGarbage, which also decrements the counters. That means that,
+//     even if a Delete(Seeder|Leecher) call removes the last peer from a swarm,
+//     the infohash counter is not changed and the infohash is left in the
+//     addressFamily hash until it will be cleaned up by collectGarbage.
+//   - collectGarbage must run regularly.
+//   - A WATCH ... MULTI ... EXEC block fails, if between the WATCH and the 'EXEC'
+//     any of the watched keys have changed. The location of the 'MULTI' doesn't
+//     matter.
 //
 // We have to analyze four cases to prove our algorithm works. I'll characterize
 // them by a tuple (number of peers in a swarm before WATCH, number of peers in
 // the swarm during the transaction).
 //
-// 1. (0,0), the easy case: The swarm is empty, we watch the key, we execute
-//	  HLEN and find it empty. We remove it and decrement the counter. It stays
-//	  empty the entire time, the transaction goes through.
-// 2. (1,n > 0): The swarm is not empty, we watch the key, we find it non-empty,
-//	  we unwatch the key. All good. No transaction is made, no transaction fails.
-// 3. (0,1): We have to analyze this in two ways.
-// - If the change happens before the HLEN call, we will see that the swarm is
-//	 not empty and start no transaction.
-// - If the change happens after the HLEN, we will attempt a transaction and it
-//   will fail. This is okay, the swarm is not empty, we will try cleaning it up
-//   next time collectGarbage runs.
-// 4. (1,0): Again, two ways:
-// - If the change happens before the HLEN, we will see an empty swarm. This
-//   situation happens if a call to Delete(Seeder|Leecher) removed the last
-//	 peer asynchronously. We will attempt a transaction, but the transaction
-//	 will fail. This is okay, the infohash key will remain in the addressFamily
-//   hash, we will attempt to clean it up the next time 'collectGarbage` runs.
-// - If the change happens after the HLEN, we will not even attempt to make the
-//	 transaction. The infohash key will remain in the addressFamil hash and
-//	 we'll attempt to clean it up the next time collectGarbage runs.
+//  1. (0,0), the easy case: The swarm is empty, we watch the key, we execute
+//     HLEN and find it empty. We remove it and decrement the counter. It stays
+//     empty the entire time, the transaction goes through.
+//  2. (1,n > 0): The swarm is not empty, we watch the key, we find it non-empty,
+//     we unwatch the key. All good. No transaction is made, no transaction fails.
+//  3. (0,1): We have to analyze this in two ways.
+//     - If the change happens before the HLEN call, we will see that the swarm is
+//     not empty and start no transaction.
+//     - If the change happens after the HLEN, we will attempt a transaction and it
+//     will fail. This is okay, the swarm is not empty, we will try cleaning it up
+//     next time collectGarbage runs.
+//  4. (1,0): Again, two ways:
+//     - If the change happens before the HLEN, we will see an empty swarm. This
+//     situation happens if a call to Delete(Seeder|Leecher) removed the last
+//     peer asynchronously. We will attempt a transaction, but the transaction
+//     will fail. This is okay, the infohash key will remain in the addressFamily
+//     hash, we will attempt to clean it up the next time 'collectGarbage` runs.
+//     - If the change happens after the HLEN, we will not even attempt to make the
+//     transaction. The infohash key will remain in the addressFamil hash and
+//     we'll attempt to clean it up the next time collectGarbage runs.
 func (ps *peerStore) collectGarbage(cutoff time.Time) error {
 	select {
 	case <-ps.closed:

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -34,12 +34,12 @@ var ErrDriverDoesNotExist = errors.New("peer store driver with that name does no
 // Implementations of the PeerStore interface must do the following in addition
 // to implementing the methods of the interface in the way documented:
 //
-// - Implement a garbage-collection strategy that ensures stale data is removed.
+//   - Implement a garbage-collection strategy that ensures stale data is removed.
 //     For example, a timestamp on each InfoHash/Peer combination can be used
 //     to track the last activity for that Peer. The entire database can then
 //     be scanned periodically and too old Peers removed. The intervals and
 //     durations involved should be configurable.
-// - IPv4 and IPv6 swarms must be isolated from each other.
+//   - IPv4 and IPv6 swarms must be isolated from each other.
 //     A PeerStore must be able to transparently handle IPv4 and IPv6 Peers, but
 //     must separate them. AnnouncePeers and ScrapeSwarm must return information
 //     about the Swarm matching the given AddressFamily only.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,3 +1,4 @@
+// Package storage provides abstractions and implementations for storing and retrieving peers from their announced infohashes.
 package storage
 
 import (


### PR DESCRIPTION
Short package docs makes the linter warnings happy, so it becomes easier to see what is really going on. Then, there is a fix for a potential attack on the Prometheus endpoint, also reported by CI.

On my fork this is now [green](https://github.com/contribforks/chihaya/actions/runs/4075701092), lets see what happens here.