### PR TITLE
Fix to HTTP header X-Forwarded-For parse to support proxy chains.

### DIFF
--- a/frontend/http/parser.go
+++ b/frontend/http/parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/chihaya/chihaya/bittorrent"
 )
@@ -162,10 +163,15 @@ func requestedIP(r *http.Request, p bittorrent.Params, opts ParseOptions) (ip ne
 
 	if opts.RealIPHeader != "" {
 		if ip := r.Header.Get(opts.RealIPHeader); ip != "" {
+			ip = removePort(strings.TrimSpace(strings.Split(ip, ",")[0]))
 			return net.ParseIP(ip), false
 		}
 	}
 
 	host, _, _ := net.SplitHostPort(r.RemoteAddr)
 	return net.ParseIP(host), false
+}
+
+func removePort(ip string) string {
+	return strings.Split(ip, ":")[0]
 }


### PR DESCRIPTION
Hello,

Ingress traffic going through a proxy chain leads to `X-Forwarded-For` headers that are comma-separated enumerations.
The first item in the list is the client, every one else are the participating proxy forming the chain of trust.

This small change picks the only IP / or the first IP of the list to avoid failing with a parse error.

It resolved the issue on my side for my open proxy and would love to see it merged upstream.

Cheers,
Alex.